### PR TITLE
Removed former stage 3.

### DIFF
--- a/versions/draft-ietf-regext-rdap-jscontact-16.html
+++ b/versions/draft-ietf-regext-rdap-jscontact-16.html
@@ -1,0 +1,3179 @@
+<!DOCTYPE html>
+<html lang="en" class="Internet-Draft">
+<head>
+<meta charset="utf-8">
+<meta content="Common,Cyrillic,Latin" name="scripts">
+<meta content="initial-scale=1.0" name="viewport">
+<title>Using JSContact in Registration Data Access Protocol (RDAP) JSON Responses</title>
+<meta content="Mario Loffredo" name="author">
+<meta content="Gavin Brown" name="author">
+<meta content="
+       This document describes an RDAP extension which represents entity contact information in
+      JSON responses using JSContact. 
+    " name="description">
+<meta content="xml2rfc 3.17.2" name="generator">
+<meta content="RDAP" name="keyword">
+<meta content="jCard" name="keyword">
+<meta content="JSContact" name="keyword">
+<meta content="draft-ietf-regext-rdap-jscontact-16" name="ietf.draft">
+<!-- Generator version information:
+  xml2rfc 3.17.2
+    Python 3.10.6
+    appdirs 1.4.4
+    ConfigArgParse 1.5.3
+    google-i18n-address 2.5.2
+    intervaltree 3.1.0
+    Jinja2 3.1.2
+    lxml 4.9.2
+    pycountry 22.3.5
+    PyYAML 6.0
+    requests 2.31.0
+    setuptools 59.6.0
+    six 1.16.0
+    wcwidth 0.2.6
+    weasyprint 59.0
+-->
+<link href="/usr/src/app/tmp/dc96043c-d7ce-490d-b3ea-178172d4be30/draft-ietf-regext-rdap-jscontact-16.xml" rel="alternate" type="application/rfc+xml">
+<link href="#copyright" rel="license">
+<style type="text/css">/*
+
+  NOTE: Changes at the bottom of this file overrides some earlier settings.
+
+  Once the style has stabilized and has been adopted as an official RFC style,
+  this can be consolidated so that style settings occur only in one place, but
+  for now the contents of this file consists first of the initial CSS work as
+  provided to the RFC Formatter (xml2rfc) work, followed by itemized and
+  commented changes found necessary during the development of the v3
+  formatters.
+
+*/
+
+/* fonts */
+@import url('https://fonts.googleapis.com/css?family=Noto+Sans'); /* Sans-serif */
+@import url('https://fonts.googleapis.com/css?family=Noto+Serif'); /* Serif (print) */
+@import url('https://fonts.googleapis.com/css?family=Roboto+Mono'); /* Monospace */
+
+:root {
+  --font-sans: 'Noto Sans', Arial, Helvetica, sans-serif;
+  --font-serif: 'Noto Serif', 'Times', 'Times New Roman', serif;
+  --font-mono: 'Roboto Mono', Courier, 'Courier New', monospace;
+}
+
+@viewport {
+  zoom: 1.0;
+}
+@-ms-viewport {
+  width: extend-to-zoom;
+  zoom: 1.0;
+}
+/* general and mobile first */
+html {
+}
+body {
+  max-width: 90%;
+  margin: 1.5em auto;
+  color: #222;
+  background-color: #fff;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  line-height: 1.6;
+  scroll-behavior: smooth;
+}
+.ears {
+  display: none;
+}
+
+/* headings */
+#title, h1, h2, h3, h4, h5, h6 {
+  margin: 1em 0 0.5em;
+  font-weight: bold;
+  line-height: 1.3;
+}
+#title {
+  clear: both;
+  border-bottom: 1px solid #ddd;
+  margin: 0 0 0.5em 0;
+  padding: 1em 0 0.5em;
+}
+.author {
+  padding-bottom: 4px;
+}
+h1 {
+  font-size: 26px;
+  margin: 1em 0;
+}
+h2 {
+  font-size: 22px;
+  margin-top: -20px;  /* provide offset for in-page anchors */
+  padding-top: 33px;
+}
+h3 {
+  font-size: 18px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h4 {
+  font-size: 16px;
+  margin-top: -36px;  /* provide offset for in-page anchors */
+  padding-top: 42px;
+}
+h5, h6 {
+  font-size: 14px;
+}
+#n-copyright-notice {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 1em;
+  margin-bottom: 1em;
+}
+/* general structure */
+p {
+  padding: 0;
+  margin: 0 0 1em 0;
+  text-align: left;
+}
+div, span {
+  position: relative;
+}
+div {
+  margin: 0;
+}
+.alignRight.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignRight.art-text pre {
+  padding: 0;
+}
+.alignRight {
+  margin: 1em 0;
+}
+.alignRight > *:first-child {
+  border: none;
+  margin: 0;
+  float: right;
+  clear: both;
+}
+.alignRight > *:nth-child(2) {
+  clear: both;
+  display: block;
+  border: none;
+}
+svg {
+  display: block;
+}
+svg[font-family~="serif" i], svg [font-family~="serif" i] {
+  font-family: var(--font-serif);
+}
+svg[font-family~="sans-serif" i], svg [font-family~="sans-serif" i] {
+  font-family: var(--font-sans);
+}
+svg[font-family~="monospace" i], svg [font-family~="monospace" i] {
+  font-family: var(--font-mono);
+}
+.alignCenter.art-text {
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 3px;
+  padding: 1em 1em 0;
+  margin-bottom: 1.5em;
+}
+.alignCenter.art-text pre {
+  padding: 0;
+}
+.alignCenter {
+  margin: 1em 0;
+}
+.alignCenter > *:first-child {
+  display: table;
+  border: none;
+  margin: 0 auto;
+}
+
+/* lists */
+ol, ul {
+  padding: 0;
+  margin: 0 0 1em 2em;
+}
+ol ol, ul ul, ol ul, ul ol {
+  margin-left: 1em;
+}
+li {
+  margin: 0 0 0.25em 0;
+}
+.ulCompact li {
+  margin: 0;
+}
+ul.empty, .ulEmpty {
+  list-style-type: none;
+}
+ul.empty li, .ulEmpty li {
+  margin-top: 0.5em;
+}
+ul.ulBare, li.ulBare {
+  margin-left: 0em !important;
+}
+ul.compact, .ulCompact,
+ol.compact, .olCompact {
+  line-height: 100%;
+  margin: 0 0 0 2em;
+}
+
+/* definition lists */
+dl {
+}
+dl > dt {
+  float: left;
+  margin-right: 1em;
+}
+/* 
+dl.nohang > dt {
+  float: none;
+}
+*/
+dl > dd {
+  margin-bottom: .8em;
+  min-height: 1.3em;
+}
+dl.compact > dd, .dlCompact > dd {
+  margin-bottom: 0em;
+}
+dl > dd > dl {
+  margin-top: 0.5em;
+  margin-bottom: 0em;
+}
+
+/* links */
+a {
+  text-decoration: none;
+}
+a[href] {
+  color: #22e; /* Arlen: WCAG 2019 */
+}
+a[href]:hover {
+  background-color: #f2f2f2;
+}
+figcaption a[href],
+a[href].selfRef,
+.iref + a[href].internal {
+  color: #222;
+}
+/* XXX probably not this:
+a.selfRef:hover {
+  background-color: transparent;
+  cursor: default;
+} */
+
+/* Figures */
+tt, code, pre {
+  background-color: #f9f9f9;
+  font-family: var(--font-mono);
+}
+pre {
+  border: 1px solid #eee;
+  margin: 0;
+  padding: 1em;
+}
+img {
+  max-width: 100%;
+}
+figure {
+  margin: 0;
+}
+figure blockquote {
+  margin: 0.8em 0.4em 0.4em;
+}
+figcaption {
+  font-style: italic;
+  margin: 0 0 1em 0;
+}
+@media screen {
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+    max-width: calc(100% - 22px);
+  }
+}
+
+/* aside, blockquote */
+aside, blockquote {
+  margin-left: 0;
+  padding: 1.2em 2em;
+}
+blockquote {
+  background-color: #f9f9f9;
+  color: #111; /* Arlen: WCAG 2019 */
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  margin: 1em 0;
+}
+cite {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+
+/* tables */
+table {
+  width: 100%;
+  margin: 0 0 1em;
+  border-collapse: collapse;
+  border: 1px solid #eee;
+}
+th, td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.5em 0.75em;
+}
+th {
+  text-align: left;
+  background-color: #e9e9e9;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f5f5f5;
+}
+table caption {
+  font-style: italic;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+table p {
+  /* XXX to avoid bottom margin on table row signifiers. If paragraphs should
+     be allowed within tables more generally, it would be far better to select on a class. */
+  margin: 0;
+}
+
+/* pilcrow */
+a.pilcrow {
+  color: #666; /* Arlen: AHDJ 2019 */
+  text-decoration: none;
+  visibility: hidden;
+  user-select: none;
+  -ms-user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+@media screen {
+  aside:hover > a.pilcrow,
+  p:hover > a.pilcrow,
+  blockquote:hover > a.pilcrow,
+  div:hover > a.pilcrow,
+  li:hover > a.pilcrow,
+  pre:hover > a.pilcrow {
+    visibility: visible;
+  }
+  a.pilcrow:hover {
+    background-color: transparent;
+  }
+}
+
+/* misc */
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+}
+.bcp14 {
+  font-variant: small-caps;
+}
+
+.role {
+  font-variant: all-small-caps;
+}
+
+/* info block */
+#identifiers {
+  margin: 0;
+  font-size: 0.9em;
+}
+#identifiers dt {
+  width: 3em;
+  clear: left;
+}
+#identifiers dd {
+  float: left;
+  margin-bottom: 0;
+}
+/* Fix PDF info block run off issue */
+@media print {
+  #identifiers dd {
+    float: none;
+  }
+}
+#identifiers .authors .author {
+  display: inline-block;
+  margin-right: 1.5em;
+}
+#identifiers .authors .org {
+  font-style: italic;
+}
+
+/* The prepared/rendered info at the very bottom of the page */
+.docInfo {
+  color: #666; /* Arlen: WCAG 2019 */
+  font-size: 0.9em;
+  font-style: italic;
+  margin-top: 2em;
+}
+.docInfo .prepared {
+  float: left;
+}
+.docInfo .prepared {
+  float: right;
+}
+
+/* table of contents */
+#toc  {
+  padding: 0.75em 0 2em 0;
+  margin-bottom: 1em;
+}
+nav.toc ul {
+  margin: 0 0.5em 0 0;
+  padding: 0;
+  list-style: none;
+}
+nav.toc li {
+  line-height: 1.3em;
+  margin: 0.75em 0;
+  padding-left: 1.2em;
+  text-indent: -1.2em;
+}
+/* references */
+.references dt {
+  text-align: right;
+  font-weight: bold;
+  min-width: 7em;
+}
+.references dd {
+  margin-left: 8em;
+  overflow: auto;
+}
+
+.refInstance {
+  margin-bottom: 1.25em;
+}
+
+.references .ascii {
+  margin-bottom: 0.25em;
+}
+
+/* index */
+.index ul {
+  margin: 0 0 0 1em;
+  padding: 0;
+  list-style: none;
+}
+.index ul ul {
+  margin: 0;
+}
+.index li {
+  margin: 0;
+  text-indent: -2em;
+  padding-left: 2em;
+  padding-bottom: 5px;
+}
+.indexIndex {
+  margin: 0.5em 0 1em;
+}
+.index a {
+  font-weight: 700;
+}
+/* make the index two-column on all but the smallest screens */
+@media (min-width: 600px) {
+  .index ul {
+    -moz-column-count: 2;
+    -moz-column-gap: 20px;
+  }
+  .index ul ul {
+    -moz-column-count: 1;
+    -moz-column-gap: 0;
+  }
+}
+
+/* authors */
+address.vcard {
+  font-style: normal;
+  margin: 1em 0;
+}
+
+address.vcard .nameRole {
+  font-weight: 700;
+  margin-left: 0;
+}
+address.vcard .label {
+  font-family: var(--font-sans);
+  margin: 0.5em 0;
+}
+address.vcard .type {
+  display: none;
+}
+.alternative-contact {
+  margin: 1.5em 0 1em;
+}
+hr.addr {
+  border-top: 1px dashed;
+  margin: 0;
+  color: #ddd;
+  max-width: calc(100% - 16px);
+}
+
+/* temporary notes */
+.rfcEditorRemove::before {
+  position: absolute;
+  top: 0.2em;
+  right: 0.2em;
+  padding: 0.2em;
+  content: "The RFC Editor will remove this note";
+  color: #9e2a00; /* Arlen: WCAG 2019 */
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+}
+.rfcEditorRemove {
+  position: relative;
+  padding-top: 1.8em;
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  border-radius: 3px;
+}
+.cref {
+  background-color: #ffd; /* Arlen: WCAG 2019 */
+  padding: 2px 4px;
+}
+.crefSource {
+  font-style: italic;
+}
+/* alternative layout for smaller screens */
+@media screen and (max-width: 1023px) {
+  body {
+    padding-top: 2em;
+  }
+  #title {
+    padding: 1em 0;
+  }
+  h1 {
+    font-size: 24px;
+  }
+  h2 {
+    font-size: 20px;
+    margin-top: -18px;  /* provide offset for in-page anchors */
+    padding-top: 38px;
+  }
+  #identifiers dd {
+    max-width: 60%;
+  }
+  #toc {
+    position: fixed;
+    z-index: 2;
+    top: 0;
+    right: 0;
+    padding: 0;
+    margin: 0;
+    background-color: inherit;
+    border-bottom: 1px solid #ccc;
+  }
+  #toc h2 {
+    margin: -1px 0 0 0;
+    padding: 4px 0 4px 6px;
+    padding-right: 1em;
+    min-width: 190px;
+    font-size: 1.1em;
+    text-align: right;
+    background-color: #444;
+    color: white;
+    cursor: pointer;
+  }
+  #toc h2::before { /* css hamburger */
+    float: right;
+    position: relative;
+    width: 1em;
+    height: 1px;
+    left: -164px;
+    margin: 6px 0 0 0;
+    background: white none repeat scroll 0 0;
+    box-shadow: 0 4px 0 0 white, 0 8px 0 0 white;
+    content: "";
+  }
+  #toc nav {
+    display: none;
+    padding: 0.5em 1em 1em;
+    overflow: auto;
+    height: calc(100vh - 48px);
+    border-left: 1px solid #ddd;
+  }
+}
+
+/* alternative layout for wide screens */
+@media screen and (min-width: 1024px) {
+  body {
+    max-width: 724px;
+    margin: 42px auto;
+    padding-left: 1.5em;
+    padding-right: 29em;
+  }
+  #toc {
+    position: fixed;
+    top: 42px;
+    right: 42px;
+    width: 25%;
+    margin: 0;
+    padding: 0 1em;
+    z-index: 1;
+  }
+  #toc h2 {
+    border-top: none;
+    border-bottom: 1px solid #ddd;
+    font-size: 1em;
+    font-weight: normal;
+    margin: 0;
+    padding: 0.25em 1em 1em 0;
+  }
+  #toc nav {
+    display: block;
+    height: calc(90vh - 84px);
+    bottom: 0;
+    padding: 0.5em 0 0;
+    overflow: auto;
+  }
+  img { /* future proofing */
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+/* pagination */
+@media print {
+  body {
+
+    width: 100%;
+  }
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  #n-copyright-notice {
+    border-bottom: none;
+  }
+  #toc, #n-introduction {
+    page-break-before: always;
+  }
+  #toc {
+    border-top: none;
+    padding-top: 0;
+  }
+  figure, pre {
+    page-break-inside: avoid;
+  }
+  figure {
+    overflow: scroll;
+  }
+  .breakable pre {
+    break-inside: auto;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    page-break-after: avoid;
+  }
+  h2+*, h3+*, h4+*, h5+*, h6+* {
+    page-break-before: avoid;
+  }
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    font-size: 10pt;
+  }
+  table {
+    border: 1px solid #ddd;
+  }
+  td {
+    border-top: 1px solid #ddd;
+  }
+}
+
+/* This is commented out here, as the string-set: doesn't
+   pass W3C validation currently */
+/*
+.ears thead .left {
+  string-set: ears-top-left content();
+}
+
+.ears thead .center {
+  string-set: ears-top-center content();
+}
+
+.ears thead .right {
+  string-set: ears-top-right content();
+}
+
+.ears tfoot .left {
+  string-set: ears-bottom-left content();
+}
+
+.ears tfoot .center {
+  string-set: ears-bottom-center content();
+}
+
+.ears tfoot .right {
+  string-set: ears-bottom-right content();
+}
+*/
+
+@page :first {
+  padding-top: 0;
+  @top-left {
+    content: normal;
+    border: none;
+  }
+  @top-center {
+    content: normal;
+    border: none;
+  }
+  @top-right {
+    content: normal;
+    border: none;
+  }
+}
+
+@page {
+  size: A4;
+  margin-bottom: 45mm;
+  padding-top: 20px;
+  /* The following is commented out here, but set appropriately by in code, as
+     the content depends on the document */
+  /*
+  @top-left {
+    content: 'Internet-Draft';
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-left {
+    content: string(ears-top-left);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-center {
+    content: string(ears-top-center);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @top-right {
+    content: string(ears-top-right);
+    vertical-align: bottom;
+    border-bottom: solid 1px #ccc;
+  }
+  @bottom-left {
+    content: string(ears-bottom-left);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-center {
+    content: string(ears-bottom-center);
+    vertical-align: top;
+    border-top: solid 1px #ccc;
+  }
+  @bottom-right {
+      content: '[Page ' counter(page) ']';
+      vertical-align: top;
+      border-top: solid 1px #ccc;
+  }
+  */
+
+}
+
+/* Changes introduced to fix issues found during implementation */
+/* Make sure links are clickable even if overlapped by following H* */
+a {
+  z-index: 2;
+}
+/* Separate body from document info even without intervening H1 */
+section {
+  clear: both;
+}
+
+
+/* Top align author divs, to avoid names without organization dropping level with org names */
+.author {
+  vertical-align: top;
+}
+
+/* Leave room in document info to show Internet-Draft on one line */
+#identifiers dt {
+  width: 8em;
+}
+
+/* Don't waste quite as much whitespace between label and value in doc info */
+#identifiers dd {
+  margin-left: 1em;
+}
+
+/* Give floating toc a background color (needed when it's a div inside section */
+#toc {
+  background-color: white;
+}
+
+/* Make the collapsed ToC header render white on gray also when it's a link */
+@media screen and (max-width: 1023px) {
+  #toc h2 a,
+  #toc h2 a:link,
+  #toc h2 a:focus,
+  #toc h2 a:hover,
+  #toc a.toplink,
+  #toc a.toplink:hover {
+    color: white;
+    background-color: #444;
+    text-decoration: none;
+  }
+}
+
+/* Give the bottom of the ToC some whitespace */
+@media screen and (min-width: 1024px) {
+  #toc {
+    padding: 0 0 1em 1em;
+  }
+}
+
+/* Style section numbers with more space between number and title */
+.section-number {
+  padding-right: 0.5em;
+}
+
+/* prevent monospace from becoming overly large */
+tt, code, pre {
+  font-size: 95%;
+}
+
+/* Fix the height/width aspect for ascii art*/
+.sourcecode pre,
+.art-text pre {
+  line-height: 1.12;
+}
+
+
+/* Add styling for a link in the ToC that points to the top of the document */
+a.toplink {
+  float: right;
+  margin-right: 0.5em;
+}
+
+/* Fix the dl styling to match the RFC 7992 attributes */
+dl > dt,
+dl.dlParallel > dt {
+  float: left;
+  margin-right: 1em;
+}
+dl.dlNewline > dt {
+  float: none;
+}
+
+/* Provide styling for table cell text alignment */
+table td.text-left,
+table th.text-left {
+  text-align: left;
+}
+table td.text-center,
+table th.text-center {
+  text-align: center;
+}
+table td.text-right,
+table th.text-right {
+  text-align: right;
+}
+
+/* Make the alternative author contact information look less like just another
+   author, and group it closer with the primary author contact information */
+.alternative-contact {
+  margin: 0.5em 0 0.25em 0;
+}
+address .non-ascii {
+  margin: 0 0 0 2em;
+}
+
+/* With it being possible to set tables with alignment
+  left, center, and right, { width: 100%; } does not make sense */
+table {
+  width: auto;
+}
+
+/* Avoid reference text that sits in a block with very wide left margin,
+   because of a long floating dt label.*/
+.references dd {
+  overflow: visible;
+}
+
+/* Control caption placement */
+caption {
+  caption-side: bottom;
+}
+
+/* Limit the width of the author address vcard, so names in right-to-left
+   script don't end up on the other side of the page. */
+
+address.vcard {
+  max-width: 30em;
+  margin-right: auto;
+}
+
+/* For address alignment dependent on LTR or RTL scripts */
+address div.left {
+  text-align: left;
+}
+address div.right {
+  text-align: right;
+}
+
+/* Provide table alignment support.  We can't use the alignX classes above
+   since they do unwanted things with caption and other styling. */
+table.right {
+ margin-left: auto;
+ margin-right: 0;
+}
+table.center {
+ margin-left: auto;
+ margin-right: auto;
+}
+table.left {
+ margin-left: 0;
+ margin-right: auto;
+}
+
+/* Give the table caption label the same styling as the figcaption */
+caption a[href] {
+  color: #222;
+}
+
+@media print {
+  .toplink {
+    display: none;
+  }
+
+  /* avoid overwriting the top border line with the ToC header */
+  #toc {
+    padding-top: 1px;
+  }
+
+  /* Avoid page breaks inside dl and author address entries */
+  .vcard {
+    page-break-inside: avoid;
+  }
+
+}
+/* Tweak the bcp14 keyword presentation */
+.bcp14 {
+  font-variant: small-caps;
+  font-weight: bold;
+  font-size: 0.9em;
+}
+/* Tweak the invisible space above H* in order not to overlay links in text above */
+ h2 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 31px;
+ }
+ h3 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+ h4 {
+  margin-top: -18px;  /* provide offset for in-page anchors */
+  padding-top: 24px;
+ }
+/* Float artwork pilcrow to the right */
+@media screen {
+  .artwork a.pilcrow {
+    display: block;
+    line-height: 0.7;
+    margin-top: 0.15em;
+  }
+}
+/* Make pilcrows on dd visible */
+@media screen {
+  dd:hover > a.pilcrow {
+    visibility: visible;
+  }
+}
+/* Make the placement of figcaption match that of a table's caption
+   by removing the figure's added bottom margin */
+.alignLeft.art-text,
+.alignCenter.art-text,
+.alignRight.art-text {
+   margin-bottom: 0;
+}
+.alignLeft,
+.alignCenter,
+.alignRight {
+  margin: 1em 0 0 0;
+}
+/* In print, the pilcrow won't show on hover, so prevent it from taking up space,
+   possibly even requiring a new line */
+@media print {
+  a.pilcrow {
+    display: none;
+  }
+}
+/* Styling for the external metadata */
+div#external-metadata {
+  background-color: #eee;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: none;
+}
+div#internal-metadata {
+  padding: 0.5em;                       /* to match the external-metadata padding */
+}
+/* Styling for title RFC Number */
+h1#rfcnum {
+  clear: both;
+  margin: 0 0 -1em;
+  padding: 1em 0 0 0;
+}
+/* Make .olPercent look the same as <ol><li> */
+dl.olPercent > dd {
+  margin-bottom: 0.25em;
+  min-height: initial;
+}
+/* Give aside some styling to set it apart */
+aside {
+  border-left: 1px solid #ddd;
+  margin: 1em 0 1em 2em;
+  padding: 0.2em 2em;
+}
+aside > dl,
+aside > ol,
+aside > ul,
+aside > table,
+aside > p {
+  margin-bottom: 0.5em;
+}
+/* Additional page break settings */
+@media print {
+  figcaption, table caption {
+    page-break-before: avoid;
+  }
+}
+/* Font size adjustments for print */
+@media print {
+  body  { font-size: 10pt;      line-height: normal; max-width: 96%; }
+  h1    { font-size: 1.72em;    padding-top: 1.5em; } /* 1*1.2*1.2*1.2 */
+  h2    { font-size: 1.44em;    padding-top: 1.5em; } /* 1*1.2*1.2 */
+  h3    { font-size: 1.2em;     padding-top: 1.5em; } /* 1*1.2 */
+  h4    { font-size: 1em;       padding-top: 1.5em; }
+  h5, h6 { font-size: 1em;      margin: initial; padding: 0.5em 0 0.3em; }
+}
+/* Sourcecode margin in print, when there's no pilcrow */
+@media print {
+  .artwork,
+  .artwork > pre,
+  .sourcecode {
+    margin-bottom: 1em;
+  }
+}
+/* Avoid narrow tables forcing too narrow table captions, which may render badly */
+table {
+  min-width: 20em;
+}
+/* ol type a */
+ol.type-a { list-style-type: lower-alpha; }
+ol.type-A { list-style-type: upper-alpha; }
+ol.type-i { list-style-type: lower-roman; }
+ol.type-I { list-style-type: lower-roman; }
+/* Apply the print table and row borders in general, on request from the RPC,
+and increase the contrast between border and odd row background slightly */
+table {
+  border: 1px solid #ddd;
+}
+td {
+  border-top: 1px solid #ddd;
+}
+tr {
+  break-inside: avoid;
+}
+tr:nth-child(2n+1) > td {
+  background-color: #f8f8f8;
+}
+/* Use style rules to govern display of the TOC. */
+@media screen and (max-width: 1023px) {
+  #toc nav { display: none; }
+  #toc.active nav { display: block; }
+}
+/* Add support for keepWithNext */
+.keepWithNext {
+  break-after: avoid-page;
+  break-after: avoid-page;
+}
+/* Add support for keepWithPrevious */
+.keepWithPrevious {
+  break-before: avoid-page;
+}
+/* Change the approach to avoiding breaks inside artwork etc. */
+figure, pre, table, .artwork, .sourcecode  {
+  break-before: auto;
+  break-after: auto;
+}
+/* Avoid breaks between <dt> and <dd> */
+dl {
+  break-before: auto;
+  break-inside: auto;
+}
+dt {
+  break-before: auto;
+  break-after: avoid-page;
+}
+dd {
+  break-before: avoid-page;
+  break-after: auto;
+  orphans: 3;
+  widows: 3
+}
+span.break, dd.break {
+  margin-bottom: 0;
+  min-height: 0;
+  break-before: auto;
+  break-inside: auto;
+  break-after: auto;
+}
+/* Undo break-before ToC */
+@media print {
+  #toc {
+    break-before: auto;
+  }
+}
+/* Text in compact lists should not get extra bottom margin space,
+   since that would makes the list not compact */
+ul.compact p, .ulCompact p,
+ol.compact p, .olCompact p {
+ margin: 0;
+}
+/* But the list as a whole needs the extra space at the end */
+section ul.compact,
+section .ulCompact,
+section ol.compact,
+section .olCompact {
+  margin-bottom: 1em;                    /* same as p not within ul.compact etc. */
+}
+/* The tt and code background above interferes with for instance table cell
+   backgrounds.  Changed to something a bit more selective. */
+tt, code {
+  background-color: transparent;
+}
+p tt, p code, li tt, li code {
+  background-color: #f8f8f8;
+}
+/* Tweak the pre margin -- 0px doesn't come out well */
+pre {
+   margin-top: 0.5px;
+}
+/* Tweak the compact list text */
+ul.compact, .ulCompact,
+ol.compact, .olCompact,
+dl.compact, .dlCompact {
+  line-height: normal;
+}
+/* Don't add top margin for nested lists */
+li > ul, li > ol, li > dl,
+dd > ul, dd > ol, dd > dl,
+dl > dd > dl {
+  margin-top: initial;
+}
+/* Elements that should not be rendered on the same line as a <dt> */
+/* This should match the element list in writer.text.TextWriter.render_dl() */
+dd > div.artwork:first-child,
+dd > aside:first-child,
+dd > figure:first-child,
+dd > ol:first-child,
+dd > div.sourcecode:first-child,
+dd > table:first-child,
+dd > ul:first-child {
+  clear: left;
+}
+/* fix for weird browser behaviour when <dd/> is empty */
+dt+dd:empty::before{
+  content: "\00a0";
+}
+/* Make paragraph spacing inside <li> smaller than in body text, to fit better within the list */
+li > p {
+  margin-bottom: 0.5em
+}
+/* Don't let p margin spill out from inside list items */
+li > p:last-of-type:only-child {
+  margin-bottom: 0;
+}
+</style>
+<link href="rfc-local.css" rel="stylesheet" type="text/css">
+<script type="application/javascript">async function addMetadata(){try{const e=document.styleSheets[0].cssRules;for(let t=0;t<e.length;t++)if(/#identifiers/.exec(e[t].selectorText)){const a=e[t].cssText.replace("#identifiers","#external-updates");document.styleSheets[0].insertRule(a,document.styleSheets[0].cssRules.length)}}catch(e){console.log(e)}const e=document.getElementById("external-metadata");if(e)try{var t,a="",o=function(e){const t=document.getElementsByTagName("meta");for(let a=0;a<t.length;a++)if(t[a].getAttribute("name")===e)return t[a].getAttribute("content");return""}("rfc.number");if(o){t="https://www.rfc-editor.org/rfc/rfc"+o+".json";try{const e=await fetch(t);a=await e.json()}catch(e){t=document.URL.indexOf("html")>=0?document.URL.replace(/html$/,"json"):document.URL+".json";const o=await fetch(t);a=await o.json()}}if(!a)return;e.style.display="block";const s="",d="https://datatracker.ietf.org/doc",n="https://datatracker.ietf.org/ipr/search",c="https://www.rfc-editor.org/info",l=a.doc_id.toLowerCase(),i=a.doc_id.slice(0,3).toLowerCase(),f=a.doc_id.slice(3).replace(/^0+/,""),u={status:"Status",obsoletes:"Obsoletes",obsoleted_by:"Obsoleted By",updates:"Updates",updated_by:"Updated By",see_also:"See Also",errata_url:"Errata"};let h="<dl style='overflow:hidden' id='external-updates'>";["status","obsoletes","obsoleted_by","updates","updated_by","see_also","errata_url"].forEach(e=>{if("status"==e){a[e]=a[e].toLowerCase();var t=a[e].split(" "),o=t.length,w="",p=1;for(let e=0;e<o;e++)p<o?w=w+r(t[e])+" ":w+=r(t[e]),p++;a[e]=w}else if("obsoletes"==e||"obsoleted_by"==e||"updates"==e||"updated_by"==e){var g,m="",b=1;g=a[e].length;for(let t=0;t<g;t++)a[e][t]&&(a[e][t]=String(a[e][t]).toLowerCase(),m=b<g?m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>, ":m+"<a href='"+s+"/rfc/".concat(a[e][t])+"'>"+a[e][t].slice(3)+"</a>",b++);a[e]=m}else if("see_also"==e){var y,L="",C=1;y=a[e].length;for(let t=0;t<y;t++)if(a[e][t]){a[e][t]=String(a[e][t]);var _=a[e][t].slice(0,3),v=a[e][t].slice(3).replace(/^0+/,"");L=C<y?"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>, ":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>, ":"RFC"!=_?L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+_+" "+v+"</a>":L+"<a href='"+s+"/info/"+_.toLowerCase().concat(v.toLowerCase())+"'>"+v+"</a>",C++}a[e]=L}else if("errata_url"==e){var R="";R=a[e]?R+"<a href='"+a[e]+"'>Errata exist</a> | <a href='"+d+"/"+l+"'>Datatracker</a>| <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>":"<a href='"+d+"/"+l+"'>Datatracker</a> | <a href='"+n+"/?"+i+"="+f+"&submit="+i+"'>IPR</a> | <a href='"+c+"/"+l+"'>Info page</a>",a[e]=R}""!=a[e]?"Errata"==u[e]?h+=`<dt>More info:</dt><dd>${a[e]}</dd>`:h+=`<dt>${u[e]}:</dt><dd>${a[e]}</dd>`:"Errata"==u[e]&&(h+=`<dt>More info:</dt><dd>${a[e]}</dd>`)}),h+="</dl>",e.innerHTML=h}catch(e){console.log(e)}else console.log("Could not locate metadata <div> element");function r(e){return e.charAt(0).toUpperCase()+e.slice(1)}}window.removeEventListener("load",addMetadata),window.addEventListener("load",addMetadata);</script>
+</head>
+<body class="xml2rfc">
+<script src="metadata.min.js"></script>
+<table class="ears">
+<thead><tr>
+<td class="left">Internet-Draft</td>
+<td class="center">Using JSContact in RDAP</td>
+<td class="right">June 2023</td>
+</tr></thead>
+<tfoot><tr>
+<td class="left">Loffredo &amp; Brown</td>
+<td class="center">Expires 8 December 2023</td>
+<td class="right">[Page]</td>
+</tr></tfoot>
+</table>
+<div id="external-metadata" class="document-information"></div>
+<div id="internal-metadata" class="document-information">
+<dl id="identifiers">
+<dt class="label-workgroup">Workgroup:</dt>
+<dd class="workgroup">Registration Protocols Extensions</dd>
+<dt class="label-internet-draft">Internet-Draft:</dt>
+<dd class="internet-draft">draft-ietf-regext-rdap-jscontact-16</dd>
+<dt class="label-published">Published:</dt>
+<dd class="published">
+<time datetime="2023-06-06" class="published">6 June 2023</time>
+    </dd>
+<dt class="label-intended-status">Intended Status:</dt>
+<dd class="intended-status">Standards Track</dd>
+<dt class="label-expires">Expires:</dt>
+<dd class="expires"><time datetime="2023-12-08">8 December 2023</time></dd>
+<dt class="label-authors">Authors:</dt>
+<dd class="authors">
+<div class="author">
+      <div class="author-name">M. Loffredo</div>
+<div class="org">IIT-CNR/Registro.it</div>
+</div>
+<div class="author">
+      <div class="author-name">G. Brown</div>
+<div class="org">CentralNic Group plc</div>
+</div>
+</dd>
+</dl>
+</div>
+<h1 id="title">Using JSContact in Registration Data Access Protocol (RDAP) JSON Responses</h1>
+<section id="section-abstract">
+      <h2 id="abstract"><a href="#abstract" class="selfRef">Abstract</a></h2>
+<p id="section-abstract-1">This document describes an RDAP extension which represents entity contact information in
+      JSON responses using JSContact.<a href="#section-abstract-1" class="pilcrow">¶</a></p>
+</section>
+<div id="status-of-memo">
+<section id="section-boilerplate.1">
+        <h2 id="name-status-of-this-memo">
+<a href="#name-status-of-this-memo" class="section-name selfRef">Status of This Memo</a>
+        </h2>
+<p id="section-boilerplate.1-1">
+        This Internet-Draft is submitted in full conformance with the
+        provisions of BCP 78 and BCP 79.<a href="#section-boilerplate.1-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-2">
+        Internet-Drafts are working documents of the Internet Engineering Task
+        Force (IETF). Note that other groups may also distribute working
+        documents as Internet-Drafts. The list of current Internet-Drafts is
+        at <span><a href="https://datatracker.ietf.org/drafts/current/">https://datatracker.ietf.org/drafts/current/</a></span>.<a href="#section-boilerplate.1-2" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-3">
+        Internet-Drafts are draft documents valid for a maximum of six months
+        and may be updated, replaced, or obsoleted by other documents at any
+        time. It is inappropriate to use Internet-Drafts as reference
+        material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.1-4">
+        This Internet-Draft will expire on 8 December 2023.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="copyright">
+<section id="section-boilerplate.2">
+        <h2 id="name-copyright-notice">
+<a href="#name-copyright-notice" class="section-name selfRef">Copyright Notice</a>
+        </h2>
+<p id="section-boilerplate.2-1">
+            Copyright (c) 2023 IETF Trust and the persons identified as the
+            document authors. All rights reserved.<a href="#section-boilerplate.2-1" class="pilcrow">¶</a></p>
+<p id="section-boilerplate.2-2">
+            This document is subject to BCP 78 and the IETF Trust's Legal
+            Provisions Relating to IETF Documents
+            (<span><a href="https://trustee.ietf.org/license-info">https://trustee.ietf.org/license-info</a></span>) in effect on the date of
+            publication of this document. Please review these documents
+            carefully, as they describe your rights and restrictions with
+            respect to this document. Code Components extracted from this
+            document must include Revised BSD License text as described in
+            Section 4.e of the Trust Legal Provisions and are provided without
+            warranty as described in the Revised BSD License.<a href="#section-boilerplate.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="toc">
+<section id="section-toc.1">
+        <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
+<a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
+        </h2>
+<nav class="toc"><ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1">
+            <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="auto internal xref">1</a>.  <a href="#name-introduction" class="internal xref">Introduction</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.1">
+                <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-rationale" class="internal xref">Rationale</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.2">
+                <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="auto internal xref">1.2</a>.  <a href="#name-conventions-used-in-this-do" class="internal xref">Conventions Used in This Document</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.2">
+            <p id="section-toc.1-1.2.1"><a href="#section-2" class="auto internal xref">2</a>.  <a href="#name-jscontact" class="internal xref">JSContact</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
+            <p id="section-toc.1-1.3.1"><a href="#section-3" class="auto internal xref">3</a>.  <a href="#name-using-jscontact-objects-in-" class="internal xref">Using JSContact objects in RDAP Responses</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3.2.1">
+                <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="auto internal xref">3.1</a>.  <a href="#name-rdap-query-parameters" class="internal xref">RDAP Query Parameters</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
+            <p id="section-toc.1-1.4.1"><a href="#section-4" class="auto internal xref">4</a>.  <a href="#name-transition-considerations" class="internal xref">Transition Considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1">
+                <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="auto internal xref">4.1</a>.  <a href="#name-rdap-features-supporting-a-" class="internal xref">RDAP Features Supporting a Transition Process</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1.2.1">
+                    <p id="section-toc.1-1.4.2.1.2.1.1"><a href="#section-4.1.1" class="auto internal xref">4.1.1</a>.  <a href="#name-notices-and-link-relationsh" class="internal xref">Notices and Link Relationships</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.1.2.2">
+                    <p id="section-toc.1-1.4.2.1.2.2.1"><a href="#section-4.1.2" class="auto internal xref">4.1.2</a>.  <a href="#name-rdapconformance-property" class="internal xref">rdapConformance Property</a></p>
+</li>
+                </ul>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2">
+                <p id="section-toc.1-1.4.2.2.1"><a href="#section-4.2" class="auto internal xref">4.2</a>.  <a href="#name-transition-procedure" class="internal xref">Transition Procedure</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2.2.1">
+                    <p id="section-toc.1-1.4.2.2.2.1.1"><a href="#section-4.2.1" class="auto internal xref">4.2.1</a>.  <a href="#name-goals" class="internal xref">Goals</a></p>
+</li>
+                  <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2.2.2">
+                    <p id="section-toc.1-1.4.2.2.2.2.1"><a href="#section-4.2.2" class="auto internal xref">4.2.2</a>.  <a href="#name-transition-stages" class="internal xref">Transition Stages</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2.2.2.2.1">
+                        <p id="section-toc.1-1.4.2.2.2.2.2.1.1"><a href="#section-4.2.2.1" class="auto internal xref">4.2.2.1</a>.  <a href="#name-stage-1-only-jcard-provided" class="internal xref">Stage 1: only jCard provided</a></p>
+</li>
+                      <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2.2.2.2.2">
+                        <p id="section-toc.1-1.4.2.2.2.2.2.2.1"><a href="#section-4.2.2.2" class="auto internal xref">4.2.2.2</a>.  <a href="#name-stage-2-jcard-sunset" class="internal xref">Stage 2: jCard sunset</a></p>
+</li>
+                      <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2.2.2.2.3">
+                        <p id="section-toc.1-1.4.2.2.2.2.2.3.1"><a href="#section-4.2.2.3" class="auto internal xref">4.2.2.3</a>.  <a href="#name-stage-3-jcard-deprecation" class="internal xref">Stage 3: jCard deprecation</a></p>
+</li>
+                      <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4.2.2.2.2.2.4">
+                        <p id="section-toc.1-1.4.2.2.2.2.2.4.1"><a href="#section-4.2.2.4" class="auto internal xref">4.2.2.4</a>.  <a href="#name-length" class="internal xref">Length</a></p>
+</li>
+                    </ul>
+</li>
+                </ul>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5">
+            <p id="section-toc.1-1.5.1"><a href="#section-5" class="auto internal xref">5</a>.  <a href="#name-implementation-status" class="internal xref">Implementation Status</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.1">
+                <p id="section-toc.1-1.5.2.1.1"><a href="#section-5.1" class="auto internal xref">5.1</a>.  <a href="#name-iit-cnr-registroit-rdap-ser" class="internal xref">IIT-CNR/Registro.it RDAP Server</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.2">
+                <p id="section-toc.1-1.5.2.2.1"><a href="#section-5.2" class="auto internal xref">5.2</a>.  <a href="#name-iit-cnr-registroit-rdap-cli" class="internal xref">IIT-CNR/Registro.it RDAP Client</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.3">
+                <p id="section-toc.1-1.5.2.3.1"><a href="#section-5.3" class="auto internal xref">5.3</a>.  <a href="#name-clientrdaporg" class="internal xref">client.rdap.org</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.5.2.4">
+                <p id="section-toc.1-1.5.2.4.1"><a href="#section-5.4" class="auto internal xref">5.4</a>.  <a href="#name-centralnic-registry" class="internal xref">CentralNic Registry</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6">
+            <p id="section-toc.1-1.6.1"><a href="#section-6" class="auto internal xref">6</a>.  <a href="#name-iana-considerations" class="internal xref">IANA Considerations</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.1">
+                <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="auto internal xref">6.1</a>.  <a href="#name-rdap-extensions-registry" class="internal xref">RDAP Extensions Registry</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.2">
+                <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="auto internal xref">6.2</a>.  <a href="#name-rdap-json-values-registry" class="internal xref">RDAP JSON Values Registry</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.6.2.3">
+                <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="auto internal xref">6.3</a>.  <a href="#name-rdap-reverse-search-mapping" class="internal xref">RDAP Reverse Search Mapping Registry</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.7">
+            <p id="section-toc.1-1.7.1"><a href="#section-7" class="auto internal xref">7</a>.  <a href="#name-security-considerations" class="internal xref">Security Considerations</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.8">
+            <p id="section-toc.1-1.8.1"><a href="#section-8" class="auto internal xref">8</a>.  <a href="#name-acknowledgements" class="internal xref">Acknowledgements</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9">
+            <p id="section-toc.1-1.9.1"><a href="#section-9" class="auto internal xref">9</a>.  <a href="#name-references" class="internal xref">References</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.1">
+                <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="auto internal xref">9.1</a>.  <a href="#name-normative-references" class="internal xref">Normative References</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.9.2.2">
+                <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="auto internal xref">9.2</a>.  <a href="#name-informative-references" class="internal xref">Informative References</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.10">
+            <p id="section-toc.1-1.10.1"><a href="#appendix-A" class="auto internal xref">Appendix A</a>.  <a href="#name-jcard-jscontact-mapping" class="internal xref">jCard-JSContact Mapping</a></p>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11">
+            <p id="section-toc.1-1.11.1"><a href="#appendix-B" class="auto internal xref">Appendix B</a>.  <a href="#name-change-log" class="internal xref">Change Log</a></p>
+<ul class="compact toc ulBare ulEmpty">
+<li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.1">
+                <p id="section-toc.1-1.11.2.1.1"><a href="#appendix-B.1" class="auto internal xref">B.1</a>.  <a href="#name-change-from-00-to-01" class="internal xref">Change from 00 to 01</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.2">
+                <p id="section-toc.1-1.11.2.2.1"><a href="#appendix-B.2" class="auto internal xref">B.2</a>.  <a href="#name-change-from-01-to-02" class="internal xref">Change from 01 to 02</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.3">
+                <p id="section-toc.1-1.11.2.3.1"><a href="#appendix-B.3" class="auto internal xref">B.3</a>.  <a href="#name-change-from-02-to-03" class="internal xref">Change from 02 to 03</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.4">
+                <p id="section-toc.1-1.11.2.4.1"><a href="#appendix-B.4" class="auto internal xref">B.4</a>.  <a href="#name-change-from-03-to-04" class="internal xref">Change from 03 to 04</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.5">
+                <p id="section-toc.1-1.11.2.5.1"><a href="#appendix-B.5" class="auto internal xref">B.5</a>.  <a href="#name-initial-wg-version" class="internal xref">Initial WG version</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.6">
+                <p id="section-toc.1-1.11.2.6.1"><a href="#appendix-B.6" class="auto internal xref">B.6</a>.  <a href="#name-change-from-00-to-01-2" class="internal xref">Change from 00 to 01</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.7">
+                <p id="section-toc.1-1.11.2.7.1"><a href="#appendix-B.7" class="auto internal xref">B.7</a>.  <a href="#name-change-from-01-to-02-2" class="internal xref">Change from 01 to 02</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.8">
+                <p id="section-toc.1-1.11.2.8.1"><a href="#appendix-B.8" class="auto internal xref">B.8</a>.  <a href="#name-change-from-02-to-03-2" class="internal xref">Change from 02 to 03</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.9">
+                <p id="section-toc.1-1.11.2.9.1"><a href="#appendix-B.9" class="auto internal xref">B.9</a>.  <a href="#name-change-from-03-to-04-2" class="internal xref">Change from 03 to 04</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.10">
+                <p id="section-toc.1-1.11.2.10.1"><a href="#appendix-B.10" class="auto internal xref">B.10</a>. <a href="#name-change-from-04-to-05" class="internal xref">Change from 04 to 05</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.11">
+                <p id="section-toc.1-1.11.2.11.1"><a href="#appendix-B.11" class="auto internal xref">B.11</a>. <a href="#name-change-from-05-to-06" class="internal xref">Change from 05 to 06</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.12">
+                <p id="section-toc.1-1.11.2.12.1"><a href="#appendix-B.12" class="auto internal xref">B.12</a>. <a href="#name-change-from-06-to-07" class="internal xref">Change from 06 to 07</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.13">
+                <p id="section-toc.1-1.11.2.13.1"><a href="#appendix-B.13" class="auto internal xref">B.13</a>. <a href="#name-change-from-07-to-08" class="internal xref">Change from 07 to 08</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.14">
+                <p id="section-toc.1-1.11.2.14.1"><a href="#appendix-B.14" class="auto internal xref">B.14</a>. <a href="#name-change-from-08-to-09" class="internal xref">Change from 08 to 09</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.15">
+                <p id="section-toc.1-1.11.2.15.1"><a href="#appendix-B.15" class="auto internal xref">B.15</a>. <a href="#name-change-from-09-to-10" class="internal xref">Change from 09 to 10</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.16">
+                <p id="section-toc.1-1.11.2.16.1"><a href="#appendix-B.16" class="auto internal xref">B.16</a>. <a href="#name-change-from-10-to-11" class="internal xref">Change from 10 to 11</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.17">
+                <p id="section-toc.1-1.11.2.17.1"><a href="#appendix-B.17" class="auto internal xref">B.17</a>. <a href="#name-change-from-11-to-12" class="internal xref">Change from 11 to 12</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.18">
+                <p id="section-toc.1-1.11.2.18.1"><a href="#appendix-B.18" class="auto internal xref">B.18</a>. <a href="#name-change-from-12-to-13" class="internal xref">Change from 12 to 13</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.19">
+                <p id="section-toc.1-1.11.2.19.1"><a href="#appendix-B.19" class="auto internal xref">B.19</a>. <a href="#name-change-from-13-to-14" class="internal xref">Change from 13 to 14</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.20">
+                <p id="section-toc.1-1.11.2.20.1"><a href="#appendix-B.20" class="auto internal xref">B.20</a>. <a href="#name-change-from-14-to-15" class="internal xref">Change from 14 to 15</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.21">
+                <p id="section-toc.1-1.11.2.21.1"><a href="#appendix-B.21" class="auto internal xref">B.21</a>. <a href="#name-change-from-14-to-15-2" class="internal xref">Change from 14 to 15</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.11.2.22">
+                <p id="section-toc.1-1.11.2.22.1"><a href="#appendix-B.22" class="auto internal xref">B.22</a>. <a href="#name-change-from-15-to-16" class="internal xref">Change from 15 to 16</a></p>
+</li>
+            </ul>
+</li>
+          <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.12">
+            <p id="section-toc.1-1.12.1"><a href="#appendix-C" class="auto internal xref"></a><a href="#name-authors-addresses" class="internal xref">Authors' Addresses</a></p>
+</li>
+        </ul>
+</nav>
+</section>
+</div>
+<section id="section-1">
+      <h2 id="name-introduction">
+<a href="#section-1" class="section-number selfRef">1. </a><a href="#name-introduction" class="section-name selfRef">Introduction</a>
+      </h2>
+<p id="section-1-1">This document specifies an extension to the Registration Data Access Protocol (RDAP)
+      that allows RDAP servers to use JSContact <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span>
+      to represent the contact information associated with entities in RDAP responses, instead
+      of jCard <span>[<a href="#RFC7095" class="cite xref">RFC7095</a>]</span>.  It also describes the process by which an RDAP server
+      can transition from jCard to JSContact.  RDAP query and response extensions are defined to
+      facilitate the transition process.<a href="#section-1-1" class="pilcrow">¶</a></p>
+<div id="Rationale">
+<section id="section-1.1">
+        <h3 id="name-rationale">
+<a href="#section-1.1" class="section-number selfRef">1.1. </a><a href="#name-rationale" class="section-name selfRef">Rationale</a>
+        </h3>
+<p id="section-1.1-1">According to the feedback from RDAP Pilot Working Group <span>[<a href="#RDAP-PILOT-WG" class="cite xref">RDAP-PILOT-WG</a>]</span>,
+        a group of RDAP server implementers representing registries and registrars of generic
+        TLDs, the most commonly raised implementation concern, for both servers and client
+        implementers, related to the use of jCard <span>[<a href="#RFC7095" class="cite xref">RFC7095</a>]</span> to represent the
+        contact information associated with entities.  Working Group members reported jCard to be
+        unintuitive, complicated to implement for both clients and servers, and incompatible
+        with best practices for RESTful APIs.<a href="#section-1.1-1" class="pilcrow">¶</a></p>
+<p id="section-1.1-2">JSContact <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span> provides a simpler and more
+        efficient representation for contact information with regard to time and effort saved in processing it.  In addition, similarly to jCard, it provides a means to
+        represent internationalised and unstructured contact information.  Support for internationalised contact information has been
+        recognised being necessary to facilitate the future internationalisation of registration
+        data directory services.<a href="#section-1.1-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="Conventions">
+<section id="section-1.2">
+        <h3 id="name-conventions-used-in-this-do">
+<a href="#section-1.2" class="section-number selfRef">1.2. </a><a href="#name-conventions-used-in-this-do" class="section-name selfRef">Conventions Used in This Document</a>
+        </h3>
+<p id="section-1.2-1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <span>[<a href="#RFC2119" class="cite xref">RFC2119</a>]</span> <span>[<a href="#RFC8174" class="cite xref">RFC8174</a>]</span> when, and only when, they appear in all capitals, as shown here.<a href="#section-1.2-1" class="pilcrow">¶</a></p>
+<p id="section-1.2-2">The JSContact specification declares the object type "Card" which
+          represents a single contact card.  To avoid confusion, in the following of this document, the term "JSCard" is used to refer to "JSContact Card".<a href="#section-1.2-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+<div id="JSContact">
+<section id="section-2">
+      <h2 id="name-jscontact">
+<a href="#section-2" class="section-number selfRef">2. </a><a href="#name-jscontact" class="section-name selfRef">JSContact</a>
+      </h2>
+<p id="section-2-1">The JSContact specification defines a data model and JSON representation of contact
+        information that can be used for data storage and exchange in address book or directory
+        applications.  It aims to be an alternative to the vCard data format <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span>
+        and to be unambiguous, extendable and simple to process.  In contrast with jCard, it is
+        not a direct mapping from the vCard data model and expands semantics where appropriate.<a href="#section-2-1" class="pilcrow">¶</a></p>
+<p id="section-2-2">JSCard differs from jCard in that it:<a href="#section-2-2" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-2-3.1">
+          <p id="section-2-3.1.1">follows an object-oriented rather than array-oriented approach;<a href="#section-2-3.1.1" class="pilcrow">¶</a></p>
+<p id="section-2-3.1.2"></p>
+</li>
+        <li class="compact" id="section-2-3.2">
+          <p id="section-2-3.2.1">is simple to process;<a href="#section-2-3.2.1" class="pilcrow">¶</a></p>
+<p id="section-2-3.2.2"></p>
+</li>
+        <li class="compact" id="section-2-3.3">
+          <p id="section-2-3.3.1">requires no extra work in serialization/deserialization from/to a data model;<a href="#section-2-3.3.1" class="pilcrow">¶</a></p>
+<p id="section-2-3.3.2"></p>
+</li>
+        <li class="compact" id="section-2-3.4">
+          <p id="section-2-3.4.1">includes no "jagged" arrays;<a href="#section-2-3.4.1" class="pilcrow">¶</a></p>
+<p id="section-2-3.4.2"></p>
+</li>
+        <li class="compact" id="section-2-3.5">prefers maps rather than arrays to implement collections.<a href="#section-2-3.5" class="pilcrow">¶</a>
+</li>
+      </ul>
+<p id="section-2-4"><span>[<a href="#I-D.ietf-calext-jscontact-vcard" class="cite xref">I-D.ietf-calext-jscontact-vcard</a>]</span> provides informational guidance on the conversion of jCard into JSCard, and vice versa.  <a href="#jcard-jscontact-mapping" class="auto internal xref">Appendix A</a> shows JSContact counterparts for the most commonly used jCard properties in an RDAP response.<a href="#section-2-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="using-jscontact">
+<section id="section-3">
+      <h2 id="name-using-jscontact-objects-in-">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-using-jscontact-objects-in-" class="section-name selfRef">Using JSContact objects in RDAP Responses</a>
+      </h2>
+<p id="section-3-1">Entity objects in RDAP responses MAY include a "jscard" property whose value is a JSCard object instead of the "vCardArray" property defined in <span>[<a href="#RFC9083" class="cite xref">RFC9083</a>]</span>.<a href="#section-3-1" class="pilcrow">¶</a></p>
+<p id="section-3-2">Servers returning the "jscard" property in their response MUST include "jscard" in the "rdapConformance" array.<a href="#section-3-2" class="pilcrow">¶</a></p>
+<p id="section-3-3">Since most of the JSCard collections are represented as maps, map keys must be defined.  A JSContact map key MUST comply with the definition of the Id type.  To aid interoperability, RDAP providers MUST use the following Id values related to string values and labels defined in <span>[<a href="#RFC5733" class="cite xref">RFC5733</a>]</span>:<a href="#section-3-3" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-3-4.1">
+          <p id="section-3-4.1.1">"org" in the "organizations" map when there is a single &lt;contact:org&gt; element.  If both internationalised and localized forms exist, the key MUST be used for the internationalised form;<a href="#section-3-4.1.1" class="pilcrow">¶</a></p>
+<p id="section-3-4.1.2"></p>
+</li>
+        <li class="compact" id="section-3-4.2">
+          <p id="section-3-4.2.1">"addr" in the "addresses" map when there is a single &lt;contact:addr&gt; element.  If both internationalised and localized forms exist, the key MUST be used for the internationalised form;<a href="#section-3-4.2.1" class="pilcrow">¶</a></p>
+<p id="section-3-4.2.2"></p>
+</li>
+        <li class="compact" id="section-3-4.3">
+          <p id="section-3-4.3.1">"email" in the "emails" map when there is a single &lt;contact:email&gt; element;<a href="#section-3-4.3.1" class="pilcrow">¶</a></p>
+<p id="section-3-4.3.2"></p>
+</li>
+        <li class="compact" id="section-3-4.4">
+          <p id="section-3-4.4.1">"voice" in the "phones" map for the &lt;contact:voice&gt; element;<a href="#section-3-4.4.1" class="pilcrow">¶</a></p>
+<p id="section-3-4.4.2"></p>
+</li>
+        <li class="compact" id="section-3-4.5">"fax" in the "phones" map for the &lt;contact:fax&gt; element.<a href="#section-3-4.5" class="pilcrow">¶</a>
+</li>
+      </ul>
+<p id="section-3-5">The information needed to register the JSContact Id values in the "RDAP JSON Values" registry <span>[<a href="#RFC9083" class="cite xref">RFC9083</a>]</span> is described in <a href="#rdap-json-values-registry" class="auto internal xref">Section 6.2</a>.<a href="#section-3-5" class="pilcrow">¶</a></p>
+<p id="section-3-6">If present, the localized versions of name, organization and postal address MUST be added to the "localizations" map.  With reference to the defintion of localization in <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span>, an RDAP response with JSContact content MUST expand all localizations (i.e. a patch key using the syntax "{key1}/{key2}/.../{keyN}" is not allowed).  The following is an elided example of an RDAP entity lookup response including a JSCard object that presents a localized postal address (See PDF for non-ASCII character string).<a href="#section-3-6" class="pilcrow">¶</a></p>
+<span id="name-example-of-handling-localiz"></span><div id="localizations-example">
+<figure id="figure-1">
+        <div class="alignLeft art-text artwork" id="section-3-7.1">
+<pre>
+...
+"jscard": {
+  "@type" : "Card",
+  "@version" : "1.0",
+  "uid" : "7812cafe-336e-5969-988b-ad68f78ae90f",
+  "language" : "en",
+  "fullName" : "Vasya Pupkin",
+  "organizations" : {
+    "org" : {
+      "name" : "My Company"
+    }
+  },
+  "addresses" : {
+    "addr" : {
+      "street" : [ {
+        "kind" : "name",
+        "value" : "1 Street"
+      }, {
+        "kind" : "postOfficeBox",
+        "value" : "01001"
+      } ],
+      "locality" : "Kyiv",
+      "countryCode" : "UA"
+    }
+  },
+  "localizations" : {
+    "ua" : {
+      "addresses": {
+        "addr" : {
+          "street" : [ {
+            "kind" : "name",
+            "value" : "1, Улица"
+          }, {
+            "kind" : "postOfficeBox",
+            "value" : "01001"
+          } ],
+          "locality" : "Киев",
+          "countryCode" : "UA"
+        }
+      },
+      "fullName" : "Вася Пупкин",
+      "organizations": {
+        "org" : {
+          "name" : "Моя Компания"
+        }
+      }
+    }
+  }
+}
+...
+</pre>
+</div>
+<figcaption><a href="#figure-1" class="selfRef">Figure 1</a>:
+<a href="#name-example-of-handling-localiz" class="selfRef">Example of handling localizations in JSContact</a>
+        </figcaption></figure>
+</div>
+<p id="section-3-8">Implementers MAY use different mapping schemes to define keys for additional entries of the aforementioned maps or others.  For example, a mapping scheme may consist in using a trivial sequential number (e.g. "url-1", "url-2", etc.)<a href="#section-3-8" class="pilcrow">¶</a></p>
+<p id="section-3-9">The following is an example of an RDAP entity including a JSCard object that has been converted from the example in section 5.1 of <span>[<a href="#RFC9083" class="cite xref">RFC9083</a>]</span>.<a href="#section-3-9" class="pilcrow">¶</a></p>
+<span id="name-example-of-using-jscontact-"></span><div id="jscard-example">
+<figure id="figure-2">
+        <div class="alignLeft art-text artwork" id="section-3-10.1">
+<pre>
+   {
+      "rdapConformance": [
+         "rdap_level_0",
+         "jscard"
+      ],
+      "objectClassName" : "entity",
+      "handle":"XXXX",
+      "jscard":{
+        "@type": "Card",
+        "@version": "1.0",
+        "uid": "74b64df3-2d60-56b4-9df3-8594886f4456",
+        "language" : "en",
+        "fullName": "Joe User" ,
+        "name": {
+          "components": [
+            {
+              "type": "surname",
+              "value": "User"
+            },
+            {
+              "type": "given",
+              "value": "Joe"
+            },
+            {
+              "type": "suffix",
+              "value": "ing. jr"
+            },
+            {
+              "type": "suffix",
+              "value": "M.Sc."
+            }
+          ]
+        },
+        "kind": "individual",
+        "preferredLanguages": {
+          "fr": {
+            "pref": 1
+          },
+          "en": {
+            "pref": 2
+          }
+        },
+        "organizations": {
+          "org": {
+            "name": "Example"
+          }
+        },
+        "titles": {
+          "title": {
+            "kind": "title",
+            "name": "Research Scientist"
+          },
+          "role": {
+            "kind": "role",
+            "name": "Project Lead"
+          }
+        },
+        "addresses": {
+          "addr": {
+            "contexts": {
+              "work": true
+            },
+            "street": [
+              {
+                "kind": "name",
+                "value": "4321 Rue Somewhere"
+              },
+              {
+                "kind": "extension",
+                "value": "Suite 1234"
+              }
+            ],
+            "locality": "Quebec",
+            "region": "QC",
+            "postcode": "G1V 2M2",
+            "country": "Canada",
+            "countryCode": "CA",
+            "coordinates": "geo:46.772673,-71.282945",
+            "timeZone": "Etc/GMT+5"
+          },
+          "home": {
+            "contexts": {
+              "private": true
+            },
+            "fullAddress": "123 Maple Ave\nVancouver\nBC\n1239\n"
+          }
+        },
+        "phones": {
+          "voice" : {
+            "contexts": {
+              "work": true
+            },
+            "features": {
+               "voice": true,
+               "mobile": true,
+               "video": true,
+               "text": true
+            },
+            "pref": 1,
+            "number": "tel:+1-555-555-1234;ext=102"
+          }
+        },
+        "emails": {
+          "email": {
+            "contexts": {
+              "work": true
+            },
+            "address": "joe.user@example.com"
+          }
+        },
+        "cryptoKeys": {
+          "contexts": {
+            "work": true
+          },
+          "uri": "https://www.example.com/joe.user/joe.asc"
+        },
+        "links": {
+          "contexts": {
+            "private": true
+          },
+          "uri": "https://example.org"
+        }
+      },
+      "roles":[ "registrar" ],
+      "publicIds":[
+        {
+          "type":"IANA Registrar ID",
+          "identifier":"1"
+        }
+      ],
+      "remarks":[
+        {
+          "description":[
+            "She sells sea shells down by the sea shore.",
+            "Originally written by Terry Sullivan."
+          ]
+        }
+      ],
+      "links":[
+        {
+          "value":"https://example.com/entity/XXXX",
+          "rel":"self",
+          "href":"https://example.com/entity/XXXX",
+          "type" : "application/rdap+json"
+        }
+      ],
+      "events":[
+        {
+          "eventAction":"registration",
+          "eventDate":"1990-12-31T23:59:59Z"
+        }
+      ],
+      "asEventActor":[
+        {
+          "eventAction":"last changed",
+          "eventDate":"1991-12-31T23:59:59Z"
+        }
+      ]
+   }
+</pre>
+</div>
+<figcaption><a href="#figure-2" class="selfRef">Figure 2</a>:
+<a href="#name-example-of-using-jscontact-" class="selfRef">Example of using JSContact in RDAP response</a>
+        </figcaption></figure>
+</div>
+<p id="section-3-11">The use of JSContact updates the mappings of two reverse search properties, namely "fn" and "email", defined in <span>[<a href="#I-D.ietf-regext-rdap-reverse-search" class="cite xref">I-D.ietf-regext-rdap-reverse-search</a>]</span>.  Such new mappings are registered in the Reverse Search Mapping registry as described in <a href="#rdap-reverse-search-mapping-registry" class="auto internal xref">Section 6.3</a>.<a href="#section-3-11" class="pilcrow">¶</a></p>
+<div id="rdap-query-parameters-specification">
+<section id="section-3.1">
+        <h3 id="name-rdap-query-parameters">
+<a href="#section-3.1" class="section-number selfRef">3.1. </a><a href="#name-rdap-query-parameters" class="section-name selfRef">RDAP Query Parameters</a>
+        </h3>
+<p id="section-3.1-1">One new query parameter is defined for the purpose of this document.<a href="#section-3.1-1" class="pilcrow">¶</a></p>
+<p id="section-3.1-2">The parameter is an OPTIONAL extension of queries defined in <span>[<a href="#RFC9082" class="cite xref">RFC9082</a>]</span> as well as any RDAP query described by a future document whose response includes contact information.  It is as follows:<a href="#section-3.1-2" class="pilcrow">¶</a></p>
+<p id="section-3.1-3">"jscard": a boolean value that allows a client to request the "jscard" property in the RDAP response;<a href="#section-3.1-3" class="pilcrow">¶</a></p>
+<p id="section-3.1-4">This parameter is further explained in <a href="#stage2" class="auto internal xref">Section 4.2.2.2</a>.<a href="#section-3.1-4" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+<div id="transition">
+<section id="section-4">
+      <h2 id="name-transition-considerations">
+<a href="#section-4" class="section-number selfRef">4. </a><a href="#name-transition-considerations" class="section-name selfRef">Transition Considerations</a>
+      </h2>
+<div id="rdap-features-supporting-transition">
+<section id="section-4.1">
+        <h3 id="name-rdap-features-supporting-a-">
+<a href="#section-4.1" class="section-number selfRef">4.1. </a><a href="#name-rdap-features-supporting-a-" class="section-name selfRef">RDAP Features Supporting a Transition Process</a>
+        </h3>
+<section id="section-4.1.1">
+          <h4 id="name-notices-and-link-relationsh">
+<a href="#section-4.1.1" class="section-number selfRef">4.1.1. </a><a href="#name-notices-and-link-relationsh" class="section-name selfRef">Notices and Link Relationships</a>
+          </h4>
+<p id="section-4.1.1-1">RDAP allows servers to communicate service information to clients through notices.
+          According to Section 4.3 of <span>[<a href="#RFC9083" class="cite xref">RFC9083</a>]</span>, an RDAP response may contain one or more notice objects. Each notice may include a set of link objects, which can be used to provide clients
+          with references and documentation.  These link objects may have a "rel" property which defines
+          the relationship type, as described in <span>[<a href="#RFC8288" class="cite xref">RFC8288</a>]</span>, Section 4.  The transition
+          process outlined in this document uses two link relation types, namely "related" and "alternate", described in <span>[<a href="#RFC8288" class="cite xref">RFC8288</a>]</span>.<a href="#section-4.1.1-1" class="pilcrow">¶</a></p>
+</section>
+<section id="section-4.1.2">
+          <h4 id="name-rdapconformance-property">
+<a href="#section-4.1.2" class="section-number selfRef">4.1.2. </a><a href="#name-rdapconformance-property" class="section-name selfRef">rdapConformance Property</a>
+          </h4>
+<p id="section-4.1.2-1">The information about the specifications used in the construction of the response is
+            also described by the strings which appear in the "rdapConformance" property of the RDAP
+            response.<a href="#section-4.1.2-1" class="pilcrow">¶</a></p>
+</section>
+</section>
+</div>
+<div id="jcard-transition-procedure">
+<section id="section-4.2">
+        <h3 id="name-transition-procedure">
+<a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-transition-procedure" class="section-name selfRef">Transition Procedure</a>
+        </h3>
+<p id="section-4.2-1">The principles of the procedure for jCard to JSCard transition are based on the best practices in <span>[<a href="#API-DEPRECATION" class="cite xref">API-DEPRECATION</a>]</span>.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.2-2">The procedure consists of three contiguous stages.
+          During the procedure, the presence of "jscard" tag in the rdapConformance array
+          indicates that JSCard is returned instead of jCard.  The date and time format used to notify
+          clients about the stages of this procedure is defined in <span>[<a href="#RFC3339" class="cite xref">RFC3339</a>]</span>.<a href="#section-4.2-2" class="pilcrow">¶</a></p>
+<div id="jcard-deprecation-procedure-goals">
+<section id="section-4.2.1">
+          <h4 id="name-goals">
+<a href="#section-4.2.1" class="section-number selfRef">4.2.1. </a><a href="#name-goals" class="section-name selfRef">Goals</a>
+          </h4>
+<p id="section-4.2.1-1">The procedure described in this document aims to achieve the following goals:<a href="#section-4.2.1-1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-4.2.1-2.1">
+              <p id="section-4.2.1-2.1.1">only one contact representation would be included in the response;<a href="#section-4.2.1-2.1.1" class="pilcrow">¶</a></p>
+<p id="section-4.2.1-2.1.2"></p>
+</li>
+            <li class="compact" id="section-4.2.1-2.2">
+              <p id="section-4.2.1-2.2.1">the response would always be compliant to <span>[<a href="#RFC9083" class="cite xref">RFC9083</a>]</span> because:<a href="#section-4.2.1-2.2.1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-4.2.1-2.2.2.1">
+                  <p id="section-4.2.1-2.2.2.1.1">being the "jscard" property a response extension, its presence would be signaled by the "jscard" conformance tag;<a href="#section-4.2.1-2.2.2.1.1" class="pilcrow">¶</a></p>
+<p id="section-4.2.1-2.2.2.1.2"></p>
+</li>
+                <li class="compact" id="section-4.2.1-2.2.2.2">
+                  <p id="section-4.2.1-2.2.2.2.1">being "vcardArray" property optional in a response, its absence would be allowed;<a href="#section-4.2.1-2.2.2.2.1" class="pilcrow">¶</a></p>
+<p id="section-4.2.1-2.2.2.2.2"></p>
+</li>
+              </ul>
+</li>
+            <li class="compact" id="section-4.2.1-2.3">
+              <p id="section-4.2.1-2.3.1">clients would be informed about the transition timeline;<a href="#section-4.2.1-2.3.1" class="pilcrow">¶</a></p>
+<p id="section-4.2.1-2.3.2"></p>
+</li>
+            <li class="compact" id="section-4.2.1-2.4">
+              <p id="section-4.2.1-2.4.1">the backward compatibility would be guaranteed throughout the transition;<a href="#section-4.2.1-2.4.1" class="pilcrow">¶</a></p>
+<p id="section-4.2.1-2.4.2"></p>
+</li>
+            <li class="compact" id="section-4.2.1-2.5">servers and clients could execute their transitions independently.<a href="#section-4.2.1-2.5" class="pilcrow">¶</a>
+</li>
+          </ul>
+</section>
+</div>
+<div id="jcard-deprecation-procedure-stages">
+<section id="section-4.2.2">
+          <h4 id="name-transition-stages">
+<a href="#section-4.2.2" class="section-number selfRef">4.2.2. </a><a href="#name-transition-stages" class="section-name selfRef">Transition Stages</a>
+          </h4>
+<div id="stage1">
+<section id="section-4.2.2.1">
+            <h5 id="name-stage-1-only-jcard-provided">
+<a href="#section-4.2.2.1" class="section-number selfRef">4.2.2.1. </a><a href="#name-stage-1-only-jcard-provided" class="section-name selfRef">Stage 1: only jCard provided</a>
+            </h5>
+<p id="section-4.2.2.1-1">This stage corresponds to providing jCard as the default contact card <span>[<a href="#RFC9083" class="cite xref">RFC9083</a>]</span>.  The RDAP server is not able to provide an alternate format for the contact
+                card.  The rdapConformance array MUST NOT contain the "jscard" tag.<a href="#section-4.2.2.1-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="stage2">
+<section id="section-4.2.2.2">
+            <h5 id="name-stage-2-jcard-sunset">
+<a href="#section-4.2.2.2" class="section-number selfRef">4.2.2.2. </a><a href="#name-stage-2-jcard-sunset" class="section-name selfRef">Stage 2: jCard sunset</a>
+            </h5>
+<p id="section-4.2.2.2-1">During this stage, the server uses jCard by default, but the RDAP server will
+                return JSCard if the client sets the query parameter "jscard" to 1/true/yes.
+                The rdapConformance array MUST contain the "jscard" tag if JSCard is
+                returned.<a href="#section-4.2.2.2-1" class="pilcrow">¶</a></p>
+<p id="section-4.2.2.2-2">From this stage on, the RDAP server MUST include the "jscard" tag in the rdapConformance array of the help response to signal clients that JSCard can be returned instead of jCard.<a href="#section-4.2.2.2-2" class="pilcrow">¶</a></p>
+<p id="section-4.2.2.2-3">If JSCard is not requested, the RDAP server SHOULD include a notice titled "jCard sunset end".  Such
+                a notice includes a description reporting the jCard sunset end date and time and two
+                OPTIONAL links:<a href="#section-4.2.2.2-3" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-4.2.2.2-4.1">
+                <p id="section-4.2.2.2-4.1.1">"related": a link to a URI-identified resource documenting the transition procedure;<a href="#section-4.2.2.2-4.1.1" class="pilcrow">¶</a></p>
+<p id="section-4.2.2.2-4.1.2"></p>
+</li>
+              <li class="compact" id="section-4.2.2.2-4.2">"alternate": a link to an alternate result view identified
+                   by the current query string plus the parameter "jscard"
+                  set to 1/true/yes (<a href="#stage2-example1" class="auto internal xref">Figure 3</a>).<a href="#section-4.2.2.2-4.2" class="pilcrow">¶</a>
+</li>
+            </ul>
+<span id="name-jcard-sunset-jscard-not-req"></span><div id="stage2-example1">
+<figure id="figure-3">
+              <div class="alignLeft art-text artwork" id="section-4.2.2.2-5.1">
+<pre>
+"notices": [
+  {
+    "title": "jCard sunset end",
+    "description": ["2022-12-31T23:59:59Z"],
+    "links": [{
+        "value": "https://example.net/entity/XXXX",
+        "rel": "related",
+        "type": "text/html",
+        "href": "https://www.example.com/jcard_deprecation.html"
+      },
+      {
+        "value": "https://example.net/entity/XXXX",
+        "rel": "alternate",
+        "type": "application/rdap+json",
+        "href": " https://example.net/entity/XXXX?jscard=1"
+      }
+    ]
+  }
+]
+</pre>
+</div>
+<figcaption><a href="#figure-3" class="selfRef">Figure 3</a>:
+<a href="#name-jcard-sunset-jscard-not-req" class="selfRef">jCard sunset - JSCard not requested</a>
+              </figcaption></figure>
+</div>
+</section>
+</div>
+<div id="stage3">
+<section id="section-4.2.2.3">
+            <h5 id="name-stage-3-jcard-deprecation">
+<a href="#section-4.2.2.3" class="section-number selfRef">4.2.2.3. </a><a href="#name-stage-3-jcard-deprecation" class="section-name selfRef">Stage 3: jCard deprecation</a>
+            </h5>
+<p id="section-4.2.2.3-1">This stage corresponds to providing JSCard as default contact card.  The rdapConformance
+            array always contains "jscard" tag.  The RDAP server doesn't include any
+            notice about the jCard deprecation process.  The "jscard" query
+            parameter MUST be ignored.<a href="#section-4.2.2.3-1" class="pilcrow">¶</a></p>
+<p id="section-4.2.2.3-2">FOR DISCUSSION: should server signal the end of the transition by including the "jcard_deprecated" value in the rdapConformance array ? Would its usage be compliant with the rdapConformance definition in RFC 9083 ?<a href="#section-4.2.2.3-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="jcard-deprecation-procedure-length">
+<section id="section-4.2.2.4">
+            <h5 id="name-length">
+<a href="#section-4.2.2.4" class="section-number selfRef">4.2.2.4. </a><a href="#name-length" class="section-name selfRef">Length</a>
+            </h5>
+<p id="section-4.2.2.4-1">The length of the jCard sunset period is not fixed by this
+            specification.  Best practices in REST API deprecation suggest that, depending on the
+            deprecated API's reach, user base and service offering, a convenient time could be
+            anywhere between 3 - 8 months.  Anyway, RDAP providers are RECOMMENDED to monitor the
+            server log to figure out whether the declared time need to be changed to meet client
+            requirements.<a href="#section-4.2.2.4-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+</section>
+</div>
+</section>
+</div>
+</section>
+</div>
+<div id="impl-status">
+<section id="section-5">
+      <h2 id="name-implementation-status">
+<a href="#section-5" class="section-number selfRef">5. </a><a href="#name-implementation-status" class="section-name selfRef">Implementation Status</a>
+      </h2>
+<p id="section-5-1">NOTE: Please remove this section and the reference to RFC 7942 prior to publication as
+        an RFC.<a href="#section-5-1" class="pilcrow">¶</a></p>
+<p id="section-5-2">This section records the status of known implementations of the protocol defined by
+        this specification at the time of posting of this Internet-Draft, and is based on a
+        proposal described in RFC 7942 <span>[<a href="#RFC7942" class="cite xref">RFC7942</a>]</span>.  The description of
+        implementations in this section is intended to assist the IETF in its decision processes
+        in progressing drafts to RFCs.  Please note that the listing of any individual
+        implementation here does not imply endorsement by the IETF.  Furthermore, no effort has
+        been spent to verify the information presented here that was supplied by IETF
+        contributors.  This is not intended as, and must not be construed to be, a catalog of
+        available implementations or their features.  Readers are advised to note that other
+        implementations may exist.<a href="#section-5-2" class="pilcrow">¶</a></p>
+<p id="section-5-3">According to RFC 7942, "this will allow reviewers and working groups to assign due
+        consideration to documents that have the benefit of running code, which may serve as
+        evidence of valuable experimentation and feedback that have made the implemented
+        protocols more mature.  It is up to the individual working groups to use this information
+        as they see fit".<a href="#section-5-3" class="pilcrow">¶</a></p>
+<div id="registro-it-rdap-server">
+<section id="section-5.1">
+        <h3 id="name-iit-cnr-registroit-rdap-ser">
+<a href="#section-5.1" class="section-number selfRef">5.1. </a><a href="#name-iit-cnr-registroit-rdap-ser" class="section-name selfRef">IIT-CNR/Registro.it RDAP Server</a>
+        </h3>
+<ul class="compact">
+<li class="compact" id="section-5.1-1.1">
+            <p id="section-5.1-1.1.1">Responsible Organization: Institute of Informatics and Telematics of National
+          Research Council (IIT-CNR)/Registro.it<a href="#section-5.1-1.1.1" class="pilcrow">¶</a></p>
+<p id="section-5.1-1.1.2"></p>
+</li>
+          <li class="compact" id="section-5.1-1.2">
+            <p id="section-5.1-1.2.1">Location: <a href="https://rdap.pubtest.nic.it/domain/nic.it?jscard=1">https://rdap.pubtest.nic.it/</a><a href="#section-5.1-1.2.1" class="pilcrow">¶</a></p>
+<p id="section-5.1-1.2.2"></p>
+</li>
+          <li class="compact" id="section-5.1-1.3">
+            <p id="section-5.1-1.3.1">Description: This implementation includes support for RDAP queries using data from
+          the public test environment of .it ccTLD.<a href="#section-5.1-1.3.1" class="pilcrow">¶</a></p>
+<p id="section-5.1-1.3.2"></p>
+</li>
+          <li class="compact" id="section-5.1-1.4">
+            <p id="section-5.1-1.4.1">Level of Maturity: This is an "alpha" test implementation.<a href="#section-5.1-1.4.1" class="pilcrow">¶</a></p>
+<p id="section-5.1-1.4.2"></p>
+</li>
+          <li class="compact" id="section-5.1-1.5">
+            <p id="section-5.1-1.5.1">Coverage: This implementation includes all of the features described in this
+          specification.<a href="#section-5.1-1.5.1" class="pilcrow">¶</a></p>
+<p id="section-5.1-1.5.2"></p>
+</li>
+          <li class="compact" id="section-5.1-1.6">Contact Information: Mario Loffredo, mario.loffredo@iit.cnr.it<a href="#section-5.1-1.6" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="registro-it-rdap-client">
+<section id="section-5.2">
+        <h3 id="name-iit-cnr-registroit-rdap-cli">
+<a href="#section-5.2" class="section-number selfRef">5.2. </a><a href="#name-iit-cnr-registroit-rdap-cli" class="section-name selfRef">IIT-CNR/Registro.it RDAP Client</a>
+        </h3>
+<ul class="compact">
+<li class="compact" id="section-5.2-1.1">
+            <p id="section-5.2-1.1.1">Responsible Organization: Institute of Informatics and Telematics of National
+            Research Council (IIT-CNR)/Registro.it<a href="#section-5.2-1.1.1" class="pilcrow">¶</a></p>
+<p id="section-5.2-1.1.2"></p>
+</li>
+          <li class="compact" id="section-5.2-1.2">
+            <p id="section-5.2-1.2.1">Location: https://web-rdap.pubtest.nic.it/<a href="#section-5.2-1.2.1" class="pilcrow">¶</a></p>
+<p id="section-5.2-1.2.2"></p>
+</li>
+          <li class="compact" id="section-5.2-1.3">
+            <p id="section-5.2-1.3.1">Description: This is a Javascript web-based RDAP client. RDAP responses are
+            retrieved from RDAP servers by the browser, parsed into an HTML representation, and displayed in a format improving the user experience.
+            RDAP responses containing JSCard objects are handled identically to those containing
+            jCard objects.  Raw versions of RDAP responses including either jCard or JSCard objects are provided.<a href="#section-5.2-1.3.1" class="pilcrow">¶</a></p>
+<p id="section-5.2-1.3.2"></p>
+</li>
+          <li class="compact" id="section-5.2-1.4">
+            <p id="section-5.2-1.4.1">Level of Maturity: This is an "alpha" test implementation.<a href="#section-5.2-1.4.1" class="pilcrow">¶</a></p>
+<p id="section-5.2-1.4.2"></p>
+</li>
+          <li class="compact" id="section-5.2-1.5">
+            <p id="section-5.2-1.5.1">Coverage: This implementation includes all of the features described in this
+            specification.<a href="#section-5.2-1.5.1" class="pilcrow">¶</a></p>
+<p id="section-5.2-1.5.2"></p>
+</li>
+          <li class="compact" id="section-5.2-1.6">Contact Information: Francesco Donini, francesco.donini@iit.cnr.it<a href="#section-5.2-1.6" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="client-rdap-org">
+<section id="section-5.3">
+        <h3 id="name-clientrdaporg">
+<a href="#section-5.3" class="section-number selfRef">5.3. </a><a href="#name-clientrdaporg" class="section-name selfRef">client.rdap.org</a>
+        </h3>
+<ul class="compact">
+<li class="compact" id="section-5.3-1.1">
+            <p id="section-5.3-1.1.1">Location: https://client.rdap.org/<a href="#section-5.3-1.1.1" class="pilcrow">¶</a></p>
+<p id="section-5.3-1.1.2"></p>
+</li>
+          <li class="compact" id="section-5.3-1.2">
+            <p id="section-5.3-1.2.1">Description: This is a web-based "single page" RDAP client. RDAP responses are
+          retrieved from RDAP servers by the browser, and parsed into an HTML representation.
+          RDAP responses containing JSCard objects are handled identically to those containing
+          jCard objects.<a href="#section-5.3-1.2.1" class="pilcrow">¶</a></p>
+<p id="section-5.3-1.2.2"></p>
+</li>
+          <li class="compact" id="section-5.3-1.3">
+            <p id="section-5.3-1.3.1">Level of Maturity: This is an "alpha" test implementation.<a href="#section-5.3-1.3.1" class="pilcrow">¶</a></p>
+<p id="section-5.3-1.3.2"></p>
+</li>
+          <li class="compact" id="section-5.3-1.4">
+            <p id="section-5.3-1.4.1">Coverage: This implementation implements client support for parsing JSCard objects
+          in RDAP responses.<a href="#section-5.3-1.4.1" class="pilcrow">¶</a></p>
+<p id="section-5.3-1.4.2"></p>
+</li>
+          <li class="compact" id="section-5.3-1.5">Contact Information: Gavin Brown, feedback@rdap.org<a href="#section-5.3-1.5" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="cnic">
+<section id="section-5.4">
+        <h3 id="name-centralnic-registry">
+<a href="#section-5.4" class="section-number selfRef">5.4. </a><a href="#name-centralnic-registry" class="section-name selfRef">CentralNic Registry</a>
+        </h3>
+<ul class="compact">
+<li class="compact" id="section-5.4-1.1">
+            <p id="section-5.4-1.1.1">Responsible Organization: CentralNic Group PLC<a href="#section-5.4-1.1.1" class="pilcrow">¶</a></p>
+<p id="section-5.4-1.1.2"></p>
+</li>
+          <li class="compact" id="section-5.4-1.2">
+            <p id="section-5.4-1.2.1">Location: https://rdap.centralnic.com/{tld}<a href="#section-5.4-1.2.1" class="pilcrow">¶</a></p>
+<p id="section-5.4-1.2.2"></p>
+</li>
+          <li class="compact" id="section-5.4-1.3">
+            <p id="section-5.4-1.3.1">Description: This server is the product RDAP service for all top-level domains on the
+          CentralNic registry platform.<a href="#section-5.4-1.3.1" class="pilcrow">¶</a></p>
+<p id="section-5.4-1.3.2"></p>
+</li>
+          <li class="compact" id="section-5.4-1.4">
+            <p id="section-5.4-1.4.1">Level of Maturity: Production quality.<a href="#section-5.4-1.4.1" class="pilcrow">¶</a></p>
+<p id="section-5.4-1.4.2"></p>
+</li>
+          <li class="compact" id="section-5.4-1.5">
+            <p id="section-5.4-1.5.1">Coverage: This implementation includes all of the features described in this
+          specification.<a href="#section-5.4-1.5.1" class="pilcrow">¶</a></p>
+<p id="section-5.4-1.5.2"></p>
+</li>
+          <li class="compact" id="section-5.4-1.6">Contact Information: support@centralnic.com<a href="#section-5.4-1.6" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+</section>
+</div>
+<div id="IANA-considerations">
+<section id="section-6">
+      <h2 id="name-iana-considerations">
+<a href="#section-6" class="section-number selfRef">6. </a><a href="#name-iana-considerations" class="section-name selfRef">IANA Considerations</a>
+      </h2>
+<div id="rdap-extensions-registry">
+<section id="section-6.1">
+        <h3 id="name-rdap-extensions-registry">
+<a href="#section-6.1" class="section-number selfRef">6.1. </a><a href="#name-rdap-extensions-registry" class="section-name selfRef">RDAP Extensions Registry</a>
+        </h3>
+<p id="section-6.1-1">IANA is requested to register the following values in the RDAP Extensions Registry:<a href="#section-6.1-1" class="pilcrow">¶</a></p>
+<ul class="compact">
+<li class="compact" id="section-6.1-2.1">
+            <p id="section-6.1-2.1.1">Extension identifier: jscard<a href="#section-6.1-2.1.1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2.1.2"></p>
+</li>
+          <li class="compact" id="section-6.1-2.2">
+            <p id="section-6.1-2.2.1">Registry operator: Any<a href="#section-6.1-2.2.1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2.2.2"></p>
+</li>
+          <li class="compact" id="section-6.1-2.3">
+            <p id="section-6.1-2.3.1">Published specification: This document.<a href="#section-6.1-2.3.1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2.3.2"></p>
+</li>
+          <li class="compact" id="section-6.1-2.4">
+            <p id="section-6.1-2.4.1">Contact: IETF &lt;iesg@ietf.org&gt;<a href="#section-6.1-2.4.1" class="pilcrow">¶</a></p>
+<p id="section-6.1-2.4.2"></p>
+</li>
+          <li class="compact" id="section-6.1-2.5">Intended usage: This extension prefix identifier is used for the "jscard" member returned in the JSON response <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span>.<a href="#section-6.1-2.5" class="pilcrow">¶</a>
+</li>
+        </ul>
+</section>
+</div>
+<div id="rdap-json-values-registry">
+<section id="section-6.2">
+        <h3 id="name-rdap-json-values-registry">
+<a href="#section-6.2" class="section-number selfRef">6.2. </a><a href="#name-rdap-json-values-registry" class="section-name selfRef">RDAP JSON Values Registry</a>
+        </h3>
+<p id="section-6.2-1">With regard to the fields of the "RDAP JSON Values" registry <span>[<a href="#RFC9083" class="cite xref">RFC9083</a>]</span>, the "JSContact Id Value" type SHALL be used to register the RDAP values for the JSContact Id type as defined in <a href="#using-jscontact" class="auto internal xref">Section 3</a>.<a href="#section-6.2-1" class="pilcrow">¶</a></p>
+<p id="section-6.2-2">IANA is requested to register the following values in the "RDAP JSON Values" registry:<a href="#section-6.2-2" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlCompact dlParallel" id="section-6.2-3">
+          <dt id="section-6.2-3.1">Value:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-3.2">org<a href="#section-6.2-3.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-3.3">Type:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-3.4">JSContact Id Value<a href="#section-6.2-3.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-3.5">Description:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-3.6">The key in the JSContact "organizations" map identifiying the contact organization.<a href="#section-6.2-3.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-3.7">Registrant Name:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-3.8">IESG<a href="#section-6.2-3.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-3.9">Registrant Contact Information:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-3.10">iesg@ietf.org<a href="#section-6.2-3.10" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-3.11">Reference:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-3.12">This document<a href="#section-6.2-3.12" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="section-6.2-4">
+          <dt id="section-6.2-4.1">Value:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.2">addr<a href="#section-6.2-4.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-4.3">Type:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.4">JSContact Id Value<a href="#section-6.2-4.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-4.5">Description:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.6">The key in the JSContact "addresses" map identifiying the unique or preferred contact postal address.<a href="#section-6.2-4.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-4.7">Registrant Name:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.8">IESG<a href="#section-6.2-4.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-4.9">Registrant Contact Information:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.10">iesg@ietf.org<a href="#section-6.2-4.10" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-4.11">Reference:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-4.12">This document<a href="#section-6.2-4.12" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="section-6.2-5">
+          <dt id="section-6.2-5.1">Value:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.2">email<a href="#section-6.2-5.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-5.3">Type:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.4">JSContact Id Value<a href="#section-6.2-5.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-5.5">Description:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.6">The key in the JSContact "emails" map identifiying the unique or preferred contact email address.<a href="#section-6.2-5.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-5.7">Registrant Name:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.8">IESG<a href="#section-6.2-5.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-5.9">Registrant Contact Information:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.10">iesg@ietf.org<a href="#section-6.2-5.10" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-5.11">Reference:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-5.12">This document<a href="#section-6.2-5.12" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="section-6.2-6">
+          <dt id="section-6.2-6.1">Value:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-6.2">voice<a href="#section-6.2-6.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-6.3">Type:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-6.4">JSContact Id Value<a href="#section-6.2-6.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-6.5">Description:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-6.6">The key in the JSContact "phones" map identifiying the unique or preferred contact voice number.<a href="#section-6.2-6.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-6.7">Registrant Name:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-6.8">IESG<a href="#section-6.2-6.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-6.9">Registrant Contact Information:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-6.10">iesg@ietf.org<a href="#section-6.2-6.10" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-6.11">Reference:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-6.12">This document<a href="#section-6.2-6.12" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="section-6.2-7">
+          <dt id="section-6.2-7.1">Value:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.2">fax<a href="#section-6.2-7.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-7.3">Type:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.4">JSContact Id Value<a href="#section-6.2-7.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-7.5">Description:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.6">The key in the JSContact "phones" map identifiying the unique or preferred contact fax number.<a href="#section-6.2-7.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-7.7">Registrant Name:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.8">IESG<a href="#section-6.2-7.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-7.9">Registrant Contact Information:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.10">iesg@ietf.org<a href="#section-6.2-7.10" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.2-7.11">Reference:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.2-7.12">This document<a href="#section-6.2-7.12" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+<div id="rdap-reverse-search-mapping-registry">
+<section id="section-6.3">
+        <h3 id="name-rdap-reverse-search-mapping">
+<a href="#section-6.3" class="section-number selfRef">6.3. </a><a href="#name-rdap-reverse-search-mapping" class="section-name selfRef">RDAP Reverse Search Mapping Registry</a>
+        </h3>
+<p id="section-6.3-1">IANA is requested to register the following entries in the the "RDAP Reverse Search Mapping" registry <span>[<a href="#I-D.ietf-regext-rdap-reverse-search" class="cite xref">I-D.ietf-regext-rdap-reverse-search</a>]</span>:<a href="#section-6.3-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlCompact dlParallel" id="section-6.3-2">
+          <dt id="section-6.3-2.1">Searchable Resource Type:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.2">domains, nameservers, entities<a href="#section-6.3-2.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-2.3">Related Resource Type:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.4">entity<a href="#section-6.3-2.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-2.5">Property:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.6">fn<a href="#section-6.3-2.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-2.7">Property Path:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.8">$.entities[*].jscard.[fullName,localizations.*.fullName]<a href="#section-6.3-2.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-2.9">Registrant Name:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.10">IESG<a href="#section-6.3-2.10" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-2.11">Registrant Contact Information:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.12">iesg@ietf.org<a href="#section-6.3-2.12" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-2.13">Reference:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-2.14">This document<a href="#section-6.3-2.14" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="section-6.3-3">
+          <dt id="section-6.3-3.1">Searchable Resource Type:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-3.2">domains, nameservers, entities<a href="#section-6.3-3.2" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-3.3">Related Resource Type:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-3.4">entity<a href="#section-6.3-3.4" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-3.5">Property:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-3.6">email<a href="#section-6.3-3.6" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-3.7">Property Path:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-3.8">$.entities[*].jscard.emails.email.address<a href="#section-6.3-3.8" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-3.9">Registrant Name:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-3.10">IESG<a href="#section-6.3-3.10" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-3.11">Registrant Contact Information:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-3.12">iesg@ietf.org<a href="#section-6.3-3.12" class="pilcrow">¶</a>
+</dd>
+          <dd class="break"></dd>
+<dt id="section-6.3-3.13">Reference:</dt>
+          <dd style="margin-left: 1.5em" id="section-6.3-3.14">This document<a href="#section-6.3-3.14" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+</dl>
+</section>
+</div>
+</section>
+</div>
+<div id="security-considerations">
+<section id="section-7">
+      <h2 id="name-security-considerations">
+<a href="#section-7" class="section-number selfRef">7. </a><a href="#name-security-considerations" class="section-name selfRef">Security Considerations</a>
+      </h2>
+<p id="section-7-1">Unlike what happens for the "fn" property in jCard, the only mandatory property in JSContact, namely "uid", is not a sensitive information.  Nevertheless, RDAP operators can redact it to prevent results from being correlated.  Hence, with reference to what is described in <span>[<a href="#I-D.ietf-regext-rdap-redacted" class="cite xref">I-D.ietf-regext-rdap-redacted</a>]</span>, a redaction method must be selected based on the "uid" format.<a href="#section-7-1" class="pilcrow">¶</a></p>
+<p id="section-7-2">If "uid" is represented as a URN in the uuid namespace, the most appropriate choice is using the "Replacement Value" method along with the nil UUID as replacing value.  If it is provided in the free-text format, the "Empty Value" method should be preferred.  Otherwise, an URI value can be redacted by using any of the two methods above.  For example, the URL of the RDAP entity corresponding to the contact (e.g. "https://example.com/rdap/entity/XYZ12345") can be redacted by replacing the entity handle with a fixed literal (e.g "https://example.com/rdap/entity/XXXXX").<a href="#section-7-2" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="Acknowledgements">
+<section id="section-8">
+      <h2 id="name-acknowledgements">
+<a href="#section-8" class="section-number selfRef">8. </a><a href="#name-acknowledgements" class="section-name selfRef">Acknowledgements</a>
+      </h2>
+<p id="section-8-1">The authors would like to acknowledge the following individuals for their contributions to this document: Jasdip Singh, Andrew Newton, Marc Blanchet, Rick Wilhelm and Francesco Donini.<a href="#section-8-1" class="pilcrow">¶</a></p>
+</section>
+</div>
+<section id="section-9">
+      <h2 id="name-references">
+<a href="#section-9" class="section-number selfRef">9. </a><a href="#name-references" class="section-name selfRef">References</a>
+      </h2>
+<section id="section-9.1">
+        <h3 id="name-normative-references">
+<a href="#section-9.1" class="section-number selfRef">9.1. </a><a href="#name-normative-references" class="section-name selfRef">Normative References</a>
+        </h3>
+<dl class="references">
+<dt id="I-D.ietf-calext-jscontact">[I-D.ietf-calext-jscontact]</dt>
+        <dd>
+<span class="refAuthor">Stepanek, R.</span> and <span class="refAuthor">M. Loffredo</span>, <span class="refTitle">"JSContact: A JSON representation of contact data"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-calext-jscontact-10</span>, <time datetime="2023-04-19" class="refDate">19 April 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-calext-jscontact-10">https://datatracker.ietf.org/doc/html/draft-ietf-calext-jscontact-10</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="I-D.ietf-calext-jscontact-vcard">[I-D.ietf-calext-jscontact-vcard]</dt>
+        <dd>
+<span class="refAuthor">Loffredo, M.</span> and <span class="refAuthor">R. Stepanek</span>, <span class="refTitle">"JSContact: Converting from and to vCard"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-calext-jscontact-vcard-09</span>, <time datetime="2023-06-02" class="refDate">2 June 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-calext-jscontact-vcard-09">https://datatracker.ietf.org/doc/html/draft-ietf-calext-jscontact-vcard-09</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="I-D.ietf-regext-rdap-reverse-search">[I-D.ietf-regext-rdap-reverse-search]</dt>
+        <dd>
+<span class="refAuthor">Loffredo, M.</span> and <span class="refAuthor">M. Martinelli</span>, <span class="refTitle">"Registration Data Access Protocol (RDAP) Reverse Search"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-regext-rdap-reverse-search-22</span>, <time datetime="2023-05-02" class="refDate">2 May 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-regext-rdap-reverse-search-22">https://datatracker.ietf.org/doc/html/draft-ietf-regext-rdap-reverse-search-22</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC2119">[RFC2119]</dt>
+        <dd>
+<span class="refAuthor">Bradner, S.</span>, <span class="refTitle">"Key words for use in RFCs to Indicate Requirement Levels"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 2119</span>, <span class="seriesInfo">DOI 10.17487/RFC2119</span>, <time datetime="1997-03" class="refDate">March 1997</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc2119">https://www.rfc-editor.org/info/rfc2119</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC3339">[RFC3339]</dt>
+        <dd>
+<span class="refAuthor">Klyne, G.</span> and <span class="refAuthor">C. Newman</span>, <span class="refTitle">"Date and Time on the Internet: Timestamps"</span>, <span class="seriesInfo">RFC 3339</span>, <span class="seriesInfo">DOI 10.17487/RFC3339</span>, <time datetime="2002-07" class="refDate">July 2002</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc3339">https://www.rfc-editor.org/info/rfc3339</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC5733">[RFC5733]</dt>
+        <dd>
+<span class="refAuthor">Hollenbeck, S.</span>, <span class="refTitle">"Extensible Provisioning Protocol (EPP) Contact Mapping"</span>, <span class="seriesInfo">STD 69</span>, <span class="seriesInfo">RFC 5733</span>, <span class="seriesInfo">DOI 10.17487/RFC5733</span>, <time datetime="2009-08" class="refDate">August 2009</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc5733">https://www.rfc-editor.org/info/rfc5733</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC6350">[RFC6350]</dt>
+        <dd>
+<span class="refAuthor">Perreault, S.</span>, <span class="refTitle">"vCard Format Specification"</span>, <span class="seriesInfo">RFC 6350</span>, <span class="seriesInfo">DOI 10.17487/RFC6350</span>, <time datetime="2011-08" class="refDate">August 2011</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc6350">https://www.rfc-editor.org/info/rfc6350</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7095">[RFC7095]</dt>
+        <dd>
+<span class="refAuthor">Kewisch, P.</span>, <span class="refTitle">"jCard: The JSON Format for vCard"</span>, <span class="seriesInfo">RFC 7095</span>, <span class="seriesInfo">DOI 10.17487/RFC7095</span>, <time datetime="2014-01" class="refDate">January 2014</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7095">https://www.rfc-editor.org/info/rfc7095</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC7942">[RFC7942]</dt>
+        <dd>
+<span class="refAuthor">Sheffer, Y.</span> and <span class="refAuthor">A. Farrel</span>, <span class="refTitle">"Improving Awareness of Running Code: The Implementation Status Section"</span>, <span class="seriesInfo">BCP 205</span>, <span class="seriesInfo">RFC 7942</span>, <span class="seriesInfo">DOI 10.17487/RFC7942</span>, <time datetime="2016-07" class="refDate">July 2016</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc7942">https://www.rfc-editor.org/info/rfc7942</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8174">[RFC8174]</dt>
+        <dd>
+<span class="refAuthor">Leiba, B.</span>, <span class="refTitle">"Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</span>, <span class="seriesInfo">BCP 14</span>, <span class="seriesInfo">RFC 8174</span>, <span class="seriesInfo">DOI 10.17487/RFC8174</span>, <time datetime="2017-05" class="refDate">May 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8174">https://www.rfc-editor.org/info/rfc8174</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8288">[RFC8288]</dt>
+        <dd>
+<span class="refAuthor">Nottingham, M.</span>, <span class="refTitle">"Web Linking"</span>, <span class="seriesInfo">RFC 8288</span>, <span class="seriesInfo">DOI 10.17487/RFC8288</span>, <time datetime="2017-10" class="refDate">October 2017</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8288">https://www.rfc-editor.org/info/rfc8288</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9082">[RFC9082]</dt>
+        <dd>
+<span class="refAuthor">Hollenbeck, S.</span> and <span class="refAuthor">A. Newton</span>, <span class="refTitle">"Registration Data Access Protocol (RDAP) Query Format"</span>, <span class="seriesInfo">STD 95</span>, <span class="seriesInfo">RFC 9082</span>, <span class="seriesInfo">DOI 10.17487/RFC9082</span>, <time datetime="2021-06" class="refDate">June 2021</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9082">https://www.rfc-editor.org/info/rfc9082</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC9083">[RFC9083]</dt>
+      <dd>
+<span class="refAuthor">Hollenbeck, S.</span> and <span class="refAuthor">A. Newton</span>, <span class="refTitle">"JSON Responses for the Registration Data Access Protocol (RDAP)"</span>, <span class="seriesInfo">STD 95</span>, <span class="seriesInfo">RFC 9083</span>, <span class="seriesInfo">DOI 10.17487/RFC9083</span>, <time datetime="2021-06" class="refDate">June 2021</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc9083">https://www.rfc-editor.org/info/rfc9083</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+<section id="section-9.2">
+        <h3 id="name-informative-references">
+<a href="#section-9.2" class="section-number selfRef">9.2. </a><a href="#name-informative-references" class="section-name selfRef">Informative References</a>
+        </h3>
+<dl class="references">
+<dt id="API-DEPRECATION">[API-DEPRECATION]</dt>
+        <dd>
+<span class="refAuthor">Sandoval, K.</span>, <span class="refTitle">"How to Smartly Sunset and Deprecate APIs"</span>, <time datetime="2019-08" class="refDate">August 2019</time>, <span>&lt;<a href="https://web.archive.org/web/20200417084255/https://nordicapis.com/how-to-smartly-sunset-and-deprecate-apis/">https://web.archive.org/web/20200417084255/https://nordicapis.com/how-to-smartly-sunset-and-deprecate-apis/</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="I-D.ietf-jsonpath-base">[I-D.ietf-jsonpath-base]</dt>
+        <dd>
+<span class="refAuthor">Gössner, S.</span>, <span class="refAuthor">Normington, G.</span>, and <span class="refAuthor">C. Bormann</span>, <span class="refTitle">"JSONPath: Query expressions for JSON"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-jsonpath-base-13</span>, <time datetime="2023-04-15" class="refDate">15 April 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base-13">https://datatracker.ietf.org/doc/html/draft-ietf-jsonpath-base-13</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="I-D.ietf-regext-rdap-redacted">[I-D.ietf-regext-rdap-redacted]</dt>
+        <dd>
+<span class="refAuthor">Gould, J.</span>, <span class="refAuthor">Smith, D.</span>, <span class="refAuthor">Kolker, J.</span>, and <span class="refAuthor">R. Carney</span>, <span class="refTitle">"Redacted Fields in the Registration Data Access Protocol (RDAP) Response"</span>, <span class="refContent">Work in Progress</span>, <span class="seriesInfo">Internet-Draft, draft-ietf-regext-rdap-redacted-12</span>, <time datetime="2023-05-25" class="refDate">25 May 2023</time>, <span>&lt;<a href="https://datatracker.ietf.org/doc/html/draft-ietf-regext-rdap-redacted-12">https://datatracker.ietf.org/doc/html/draft-ietf-regext-rdap-redacted-12</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RDAP-PILOT-WG">[RDAP-PILOT-WG]</dt>
+        <dd>
+<span class="refAuthor">ICANN RDAP Pilot WG</span>, <span class="refTitle">"RDAP Pilot Report"</span>, <time datetime="2019-04" class="refDate">April 2019</time>, <span>&lt;<a href="https://www.icann.org/en/system/files/files/rdap-pilot-report-25apr19-en.pdf">https://www.icann.org/en/system/files/files/rdap-pilot-report-25apr19-en.pdf</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="RFC8605">[RFC8605]</dt>
+      <dd>
+<span class="refAuthor">Hollenbeck, S.</span> and <span class="refAuthor">R. Carney</span>, <span class="refTitle">"vCard Format Extensions: ICANN Extensions for the Registration Data Access Protocol (RDAP)"</span>, <span class="seriesInfo">RFC 8605</span>, <span class="seriesInfo">DOI 10.17487/RFC8605</span>, <time datetime="2019-05" class="refDate">May 2019</time>, <span>&lt;<a href="https://www.rfc-editor.org/info/rfc8605">https://www.rfc-editor.org/info/rfc8605</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+</dl>
+</section>
+</section>
+<div id="jcard-jscontact-mapping">
+<section id="appendix-A">
+      <h2 id="name-jcard-jscontact-mapping">
+<a href="#appendix-A" class="section-number selfRef">Appendix A. </a><a href="#name-jcard-jscontact-mapping" class="section-name selfRef">jCard-JSContact Mapping</a>
+      </h2>
+<p id="appendix-A-1">Provided that the keys defined in <a href="#using-jscontact" class="auto internal xref">Section 3</a> are used for the JSContact maps, the mapping between the most commonly used jCard properties in an RDAP response and their JSContact counterparts is shown in the following.  The mapping is done through the use of JSONPath expressions <span>[<a href="#I-D.ietf-jsonpath-base" class="cite xref">I-D.ietf-jsonpath-base</a>]</span>.<a href="#appendix-A-1" class="pilcrow">¶</a></p>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-2">
+        <dt id="appendix-A-2.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-2.2">fn<a href="#appendix-A-2.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-2.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-2.4">Section 6.2.1 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-2.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-2.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-2.6">$..vcardArray[1][?(@[0]=='fn')][3]<a href="#appendix-A-2.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-2.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-2.8">fullName<a href="#appendix-A-2.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-2.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-2.10">Section 2.2.1 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-2.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-2.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-2.12">$..jscard.[fullName,localizations.*.fullName]<a href="#appendix-A-2.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-3">
+        <dt id="appendix-A-3.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-3.2">org<a href="#appendix-A-3.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-3.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-3.4">Section 6.6.4 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-3.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-3.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-3.6">$..vcardArray[1][?(@[0]=='org')][3]<a href="#appendix-A-3.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-3.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-3.8">Organization.name<a href="#appendix-A-3.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-3.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-3.10">Section 2.2.4 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-3.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-3.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-3.12">$..jscard.[organizations.org.name,localizations.*.organizations.org.name]<a href="#appendix-A-3.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-4">
+        <dt id="appendix-A-4.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-4.2">tel with type="voice"<a href="#appendix-A-4.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-4.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-4.4">Section 6.4.1 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-4.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-4.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-4.6">$..vcardArray[1][?(@[1].type=='voice')][3]<a href="#appendix-A-4.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-4.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-4.8">Phone.number<a href="#appendix-A-4.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-4.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-4.10">Section 2.3.3 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-4.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-4.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-4.12">$..jscard.phones.voice.number<a href="#appendix-A-4.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-5">
+        <dt id="appendix-A-5.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-5.2">tel with type="fax"<a href="#appendix-A-5.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-5.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-5.4">Section 6.4.1 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-5.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-5.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-5.6">$..vcardArray[1][?(@[1].type=='fax')][3]<a href="#appendix-A-5.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-5.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-5.8">Phone.number<a href="#appendix-A-5.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-5.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-5.10">Section 2.3.3 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-5.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-5.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-5.12">$..jscard.phones.fax.number<a href="#appendix-A-5.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-6">
+        <dt id="appendix-A-6.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-6.2">email<a href="#appendix-A-6.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-6.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-6.4">Section 6.4.2 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-6.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-6.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-6.6">$..vcardArray[1][?(@[0]=='email')][3]<a href="#appendix-A-6.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-6.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-6.8">Email.address<a href="#appendix-A-6.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-6.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-6.10">Section 2.3.1 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-6.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-6.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-6.12">$..jscard.[emails.email.address,localizations.*.emails.email.address]<a href="#appendix-A-6.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-7">
+        <dt id="appendix-A-7.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-7.2">"post office box" component of adr<a href="#appendix-A-7.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-7.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-7.4">Section 6.3.1 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-7.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-7.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-7.6">$..vcardArray[1][?(@[0]=='adr')][3][1]<a href="#appendix-A-7.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-7.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-7.8">"postOfficeBox" StreetComponent of Address.street<a href="#appendix-A-7.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-7.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-7.10">Section 2.5.1 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-7.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-7.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-7.12">$..jscard.[addresses.addr.street[?(@.type=='postOfficeBox')].value,localizations.*.addresses.addr.street[?(@.type=='postOfficeBox')].value]<a href="#appendix-A-7.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-8">
+        <dt id="appendix-A-8.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-8.2">"street address" component of adr<a href="#appendix-A-8.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-8.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-8.4">Section 6.3.1 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-8.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-8.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-8.6">$..vcardArray[1][?(@[0]=='adr')][3][2]<a href="#appendix-A-8.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-8.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-8.8">"name" StreetComponent of Address.street<a href="#appendix-A-8.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-8.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-8.10">Section 2.5.1 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-8.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-8.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-8.12">$..jscard.[addresses.addr.street[?(@.type=='name')].value,localizations.*.addresses.addr.street[?(@.type=='name')].value]<a href="#appendix-A-8.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-9">
+        <dt id="appendix-A-9.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-9.2">"locality" component of adr<a href="#appendix-A-9.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-9.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-9.4">Section 6.3.1 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-9.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-9.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-9.6">$..vcardArray[1][?(@[0]=='adr')][3][3]<a href="#appendix-A-9.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-9.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-9.8">Address.locality<a href="#appendix-A-9.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-9.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-9.10">Section 2.5.1 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-9.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-9.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-9.12">$..jscard.[addresses.addr.locality,localizations.*.addresses.addr.locality]<a href="#appendix-A-9.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-10">
+        <dt id="appendix-A-10.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-10.2">"region" component of adr<a href="#appendix-A-10.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-10.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-10.4">Section 6.3.1 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-10.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-10.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-10.6">$..vcardArray[1][?(@[0]=='adr')][3][4]<a href="#appendix-A-10.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-10.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-10.8">Address.region<a href="#appendix-A-10.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-10.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-10.10">Section 2.5.1 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-10.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-10.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-10.12">$..jscard.[addresses.addr.region,localizations.*.addresses.addr.region]<a href="#appendix-A-10.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-11">
+        <dt id="appendix-A-11.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-11.2">"postal code" component of adr<a href="#appendix-A-11.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-11.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-11.4">Section 6.3.1 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-11.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-11.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-11.6">$..vcardArray[1][?(@[0]=='adr')][3][5]<a href="#appendix-A-11.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-11.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-11.8">Address.postcode<a href="#appendix-A-11.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-11.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-11.10">Section 2.5.1 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-11.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-11.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-11.12">$..jscard.[addresses.addr.postcode,localizations.*.addresses.addr.postcode]<a href="#appendix-A-11.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-12">
+        <dt id="appendix-A-12.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-12.2">"country name" component of adr<a href="#appendix-A-12.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-12.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-12.4">Section 6.3.1 of <span>[<a href="#RFC6350" class="cite xref">RFC6350</a>]</span><a href="#appendix-A-12.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-12.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-12.6">$..vcardArray[1][?(@[0]=='adr')][3][6]<a href="#appendix-A-12.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-12.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-12.8">Address.country<a href="#appendix-A-12.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-12.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-12.10">Section 2.5.1 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-12.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-12.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-12.12">$..jscard.[addresses.addr.country,localizations.*.addresses.addr.country]<a href="#appendix-A-12.12" class="pilcrow">¶</a>
+</dd>
+      <dd class="break"></dd>
+</dl>
+<span class="break"></span><dl class="dlCompact dlParallel" id="appendix-A-13">
+        <dt id="appendix-A-13.1">jCard property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-13.2">"cc" parameter of adr<a href="#appendix-A-13.2" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-13.3">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-13.4">Section 3.1 of <span>[<a href="#RFC8605" class="cite xref">RFC8605</a>]</span><a href="#appendix-A-13.4" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-13.5">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-13.6">$..vcardArray[1][?(@[0]=='adr')][1].cc<a href="#appendix-A-13.6" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-13.7">JSContact property:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-13.8">Address.countryCode<a href="#appendix-A-13.8" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-13.9">Reference:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-13.10">Section 2.5.1 of <span>[<a href="#I-D.ietf-calext-jscontact" class="cite xref">I-D.ietf-calext-jscontact</a>]</span><a href="#appendix-A-13.10" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd>
+<dt id="appendix-A-13.11">Path:</dt>
+        <dd style="margin-left: 1.5em" id="appendix-A-13.12">$..jscard.[addresses.addr.countryCode,localizations.*.addresses.addr.countryCode]<a href="#appendix-A-13.12" class="pilcrow">¶</a>
+</dd>
+        <dd class="break"></dd></dl>
+</section>
+</div>
+<section id="appendix-B">
+      <h2 id="name-change-log">
+<a href="#appendix-B" class="section-number selfRef">Appendix B. </a><a href="#name-change-log" class="section-name selfRef">Change Log</a>
+      </h2>
+<section id="appendix-B.1">
+        <h3 id="name-change-from-00-to-01">
+<a href="#appendix-B.1" class="section-number selfRef">B.1. </a><a href="#name-change-from-00-to-01" class="section-name selfRef">Change from 00 to 01</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.1-1">
+<li id="appendix-B.1-1.1">Changed category from "Best Current Practice" to "Standards
+            Track"<a href="#appendix-B.1-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.2">Replaced the example of <a href="#jscard-example" class="auto internal xref">Figure 2</a><a href="#appendix-B.1-1.2" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.3">Changed the title of the "Migration from JCard to JSCard" section to
+            "Transition Considerations"<a href="#appendix-B.1-1.3" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.4">Added <a href="#rdap-query-parameters-specification" class="auto internal xref">Section 3.1</a><a href="#appendix-B.1-1.4" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.5">Updated <a href="#IANA-considerations" class="auto internal xref">Section 6</a><a href="#appendix-B.1-1.5" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.6">Updated <a href="#security-considerations" class="auto internal xref">Section 7</a><a href="#appendix-B.1-1.6" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.7">Rearranged the description of stage 1 in <a href="#jcard-deprecation-procedure-stages" class="auto internal xref">Section 4.2.2</a><a href="#appendix-B.1-1.7" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.8">Changed the names of the transition stages 1 and 2<a href="#appendix-B.1-1.8" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.9">Corrected examples<a href="#appendix-B.1-1.9" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.10">Changed the rdapConformance tag "jscard_level_0" to "jscard"<a href="#appendix-B.1-1.10" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.1-1.11">Removed the "Best Practices for deprecating a REST API features" section,but added a useful reference.<a href="#appendix-B.1-1.11" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.2">
+        <h3 id="name-change-from-01-to-02">
+<a href="#appendix-B.2" class="section-number selfRef">B.2. </a><a href="#name-change-from-01-to-02" class="section-name selfRef">Change from 01 to 02</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.2-1">
+<li id="appendix-B.2-1.1">Removed the sentence "which cannot be represented using jCard" in <a href="#Rationale" class="auto internal xref">Section 1.1</a>.<a href="#appendix-B.2-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.3">
+        <h3 id="name-change-from-02-to-03">
+<a href="#appendix-B.3" class="section-number selfRef">B.3. </a><a href="#name-change-from-02-to-03" class="section-name selfRef">Change from 02 to 03</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.3-1">
+<li id="appendix-B.3-1.1">Updated section "Conventions Used in This Document".<a href="#appendix-B.3-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.3-1.2">Updated the contact in "IANA Considerations" section.<a href="#appendix-B.3-1.2" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.3-1.3">Changed the reference draft-loffredo-calext-jscontact-vcard to draft-ietf-calext-jscontact-vcard.<a href="#appendix-B.3-1.3" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.3-1.4">Added reference to RFC8174.<a href="#appendix-B.3-1.4" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.3-1.5">Other minor edits.<a href="#appendix-B.3-1.5" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.4">
+        <h3 id="name-change-from-03-to-04">
+<a href="#appendix-B.4" class="section-number selfRef">B.4. </a><a href="#name-change-from-03-to-04" class="section-name selfRef">Change from 03 to 04</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.4-1">
+<li id="appendix-B.4-1.1">Updated the reference draft-dalal-deprecation-header to draft-ietf-httpapi-deprecation-header.<a href="#appendix-B.4-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.5">
+        <h3 id="name-initial-wg-version">
+<a href="#appendix-B.5" class="section-number selfRef">B.5. </a><a href="#name-initial-wg-version" class="section-name selfRef">Initial WG version</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.5-1">
+<li id="appendix-B.5-1.1">Ported from draft-loffredo-regext-rdap-jcard-deprecation-04 renamed to draft-ietf-regext-rdap-jscontact-00.<a href="#appendix-B.5-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.6">
+        <h3 id="name-change-from-00-to-01-2">
+<a href="#appendix-B.6" class="section-number selfRef">B.6. </a><a href="#name-change-from-00-to-01-2" class="section-name selfRef">Change from 00 to 01</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.6-1">
+<li id="appendix-B.6-1.1">Updated <a href="#using-jscontact" class="auto internal xref">Section 3</a> and <a href="#jscard-example" class="auto internal xref">Figure 2</a>.<a href="#appendix-B.6-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.7">
+        <h3 id="name-change-from-01-to-02-2">
+<a href="#appendix-B.7" class="section-number selfRef">B.7. </a><a href="#name-change-from-01-to-02-2" class="section-name selfRef">Change from 01 to 02</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.7-1">
+<li id="appendix-B.7-1.1">Updated <a href="#JSContact" class="auto internal xref">Section 2</a> and <a href="#jscard-example" class="auto internal xref">Figure 2</a>.<a href="#appendix-B.7-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.8">
+        <h3 id="name-change-from-02-to-03-2">
+<a href="#appendix-B.8" class="section-number selfRef">B.8. </a><a href="#name-change-from-02-to-03-2" class="section-name selfRef">Change from 02 to 03</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.8-1">
+<li id="appendix-B.8-1.1">Replaced references to obsolete RFC7482 and RFC7483 with RFC9082 and RFC9083.<a href="#appendix-B.8-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.8-1.2">Updated <a href="#using-jscontact" class="auto internal xref">Section 3</a> and <a href="#jscard-example" class="auto internal xref">Figure 2</a>.<a href="#appendix-B.8-1.2" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.9">
+        <h3 id="name-change-from-03-to-04-2">
+<a href="#appendix-B.9" class="section-number selfRef">B.9. </a><a href="#name-change-from-03-to-04-2" class="section-name selfRef">Change from 03 to 04</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.9-1">
+<li id="appendix-B.9-1.1">Changed the references to Internet Drafts.<a href="#appendix-B.9-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.9-1.2">Added an example showing how localizations are treated in JSContact.<a href="#appendix-B.9-1.2" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.9-1.3">Changed the position of section "Goals" in <a href="#jcard-transition-procedure" class="auto internal xref">Section 4.2</a>.<a href="#appendix-B.9-1.3" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.9-1.4">Added three more implementations to <a href="#impl-status" class="auto internal xref">Section 5</a>.<a href="#appendix-B.9-1.4" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.9-1.5">Changed the rdapConformance tag "jscard" to "jscard_0"<a href="#appendix-B.9-1.5" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.9-1.6">Added clarifications addressing the feedback provided by Jasdip Singh about version -03.<a href="#appendix-B.9-1.6" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.9-1.7">Added <a href="#Acknowledgements" class="auto internal xref">Section 8</a>.<a href="#appendix-B.9-1.7" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.9-1.8">Other minor edits.<a href="#appendix-B.9-1.8" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.10">
+        <h3 id="name-change-from-04-to-05">
+<a href="#appendix-B.10" class="section-number selfRef">B.10. </a><a href="#name-change-from-04-to-05" class="section-name selfRef">Change from 04 to 05</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.10-1">
+<li id="appendix-B.10-1.1">Updated <a href="#jscard-example" class="auto internal xref">Figure 2</a> to make it compliant with draft-ietf-jmap-jscontact-09.<a href="#appendix-B.10-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.11">
+        <h3 id="name-change-from-05-to-06">
+<a href="#appendix-B.11" class="section-number selfRef">B.11. </a><a href="#name-change-from-05-to-06" class="section-name selfRef">Change from 05 to 06</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.11-1">
+<li id="appendix-B.11-1.1">Reviewed the notices presented in stages.<a href="#appendix-B.11-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.12">
+        <h3 id="name-change-from-06-to-07">
+<a href="#appendix-B.12" class="section-number selfRef">B.12. </a><a href="#name-change-from-06-to-07" class="section-name selfRef">Change from 06 to 07</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.12-1">
+<li id="appendix-B.12-1.1">Corrected the JSON Pointer expressions in <a href="#localizations-example" class="auto internal xref">Figure 1</a>.<a href="#appendix-B.12-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.12-1.2">Other minor edits.<a href="#appendix-B.12-1.2" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.13">
+        <h3 id="name-change-from-07-to-08">
+<a href="#appendix-B.13" class="section-number selfRef">B.13. </a><a href="#name-change-from-07-to-08" class="section-name selfRef">Change from 07 to 08</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.13-1">
+<li id="appendix-B.13-1.1">Corrected a nit in <a href="#localizations-example" class="auto internal xref">Figure 1</a>.<a href="#appendix-B.13-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.13-1.2">Removed the reference to draft-ietf-httpapi-deprecation-header.<a href="#appendix-B.13-1.2" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.13-1.3">Replaced the "deprecation" link relation type with "related".<a href="#appendix-B.13-1.3" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.13-1.4">Moved the references to JSContact drafts to the "Normative References" section.<a href="#appendix-B.13-1.4" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.14">
+        <h3 id="name-change-from-08-to-09">
+<a href="#appendix-B.14" class="section-number selfRef">B.14. </a><a href="#name-change-from-08-to-09" class="section-name selfRef">Change from 08 to 09</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.14-1">
+<li id="appendix-B.14-1.1">Updated the references to JSContact drafts due to the transfer from JMAP to CalExt.<a href="#appendix-B.14-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.15">
+        <h3 id="name-change-from-09-to-10">
+<a href="#appendix-B.15" class="section-number selfRef">B.15. </a><a href="#name-change-from-09-to-10" class="section-name selfRef">Change from 09 to 10</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.15-1">
+<li id="appendix-B.15-1.1">Updated <a href="#jscard-example" class="auto internal xref">Figure 2</a> to make it compliant with draft-ietf-calext-jscontact-02.<a href="#appendix-B.15-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.16">
+        <h3 id="name-change-from-10-to-11">
+<a href="#appendix-B.16" class="section-number selfRef">B.16. </a><a href="#name-change-from-10-to-11" class="section-name selfRef">Change from 10 to 11</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.16-1">
+<li id="appendix-B.16-1.1">Added Appendix "jCard-JSContact Mapping".<a href="#appendix-B.16-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.17">
+        <h3 id="name-change-from-11-to-12">
+<a href="#appendix-B.17" class="section-number selfRef">B.17. </a><a href="#name-change-from-11-to-12" class="section-name selfRef">Change from 11 to 12</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.17-1">
+<li id="appendix-B.17-1.1">Renamed the "jscard" property to "jscard_0".<a href="#appendix-B.17-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.17-1.2">Corrected JSONPath expressions in <a href="#jcard-jscontact-mapping" class="auto internal xref">Appendix A</a>.<a href="#appendix-B.17-1.2" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.18">
+        <h3 id="name-change-from-12-to-13">
+<a href="#appendix-B.18" class="section-number selfRef">B.18. </a><a href="#name-change-from-12-to-13" class="section-name selfRef">Change from 12 to 13</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.18-1">
+<li id="appendix-B.18-1.1">Reverted the names of response extension, the rdapConformance tag and extension identifier from  "jscard_0" to "jscard".<a href="#appendix-B.18-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.18-1.2">Corrected <a href="#localizations-example" class="auto internal xref">Figure 1</a> by removing initial '/' character from JSONPath notations related to localizations.<a href="#appendix-B.18-1.2" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.19">
+        <h3 id="name-change-from-13-to-14">
+<a href="#appendix-B.19" class="section-number selfRef">B.19. </a><a href="#name-change-from-13-to-14" class="section-name selfRef">Change from 13 to 14</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.19-1">
+<li id="appendix-B.19-1.1">Corrected <a href="#jscard-example" class="auto internal xref">Figure 2</a> by replacing "online" property with "cryptoKeys" and "links" properties.<a href="#appendix-B.19-1.1" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.20">
+        <h3 id="name-change-from-14-to-15">
+<a href="#appendix-B.20" class="section-number selfRef">B.20. </a><a href="#name-change-from-14-to-15" class="section-name selfRef">Change from 14 to 15</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.20-1">
+<li id="appendix-B.20-1.1">Corrected <a href="#localizations-example" class="auto internal xref">Figure 1</a>, <a href="#jscard-example" class="auto internal xref">Figure 2</a> and <a href="#jcard-jscontact-mapping" class="auto internal xref">Appendix A</a> to make them compliant with draft-ietf-calext-jscontact-06.<a href="#appendix-B.20-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.20-1.2">Removed mention of JSContact CardGroup object.<a href="#appendix-B.20-1.2" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.20-1.3">Renamed and changed <a href="#using-jscontact" class="auto internal xref">Section 3</a>.<a href="#appendix-B.20-1.3" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.20-1.4">Added <a href="#rdap-json-values-registry" class="auto internal xref">Section 6.2</a>.<a href="#appendix-B.20-1.4" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.21">
+        <h3 id="name-change-from-14-to-15-2">
+<a href="#appendix-B.21" class="section-number selfRef">B.21. </a><a href="#name-change-from-14-to-15-2" class="section-name selfRef">Change from 14 to 15</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.21-1">
+<li id="appendix-B.21-1.1">Corrected <a href="#localizations-example" class="auto internal xref">Figure 1</a>, <a href="#jscard-example" class="auto internal xref">Figure 2</a> and <a href="#jcard-jscontact-mapping" class="auto internal xref">Appendix A</a> to make them compliant with draft-ietf-calext-jscontact-06.<a href="#appendix-B.21-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.21-1.2">Removed mention of JSContact CardGroup object.<a href="#appendix-B.21-1.2" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.21-1.3">Renamed and changed <a href="#using-jscontact" class="auto internal xref">Section 3</a>.<a href="#appendix-B.21-1.3" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.21-1.4">Added <a href="#rdap-json-values-registry" class="auto internal xref">Section 6.2</a>.<a href="#appendix-B.21-1.4" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+<section id="appendix-B.22">
+        <h3 id="name-change-from-15-to-16">
+<a href="#appendix-B.22" class="section-number selfRef">B.22. </a><a href="#name-change-from-15-to-16" class="section-name selfRef">Change from 15 to 16</a>
+        </h3>
+<ol start="1" type="1" class="compact type-1" id="appendix-B.22-1">
+<li id="appendix-B.22-1.1">Replaced JSContact "type" with "kind" in figures.<a href="#appendix-B.22-1.1" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.22-1.2">Removed "jCard deprecation" stage and "jcard" query parameter.<a href="#appendix-B.22-1.2" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.22-1.3">Renamed "jCard deprecated" stage into "jCard deprecation".<a href="#appendix-B.22-1.3" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.22-1.4">Rephrased <a href="#security-considerations" class="auto internal xref">Section 7</a>.<a href="#appendix-B.22-1.4" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.22-1.5">Corrected JSContact examples based on draft-ietf-calext-jscontact-11.<a href="#appendix-B.22-1.5" class="pilcrow">¶</a>
+</li>
+          <li id="appendix-B.22-1.6">Fixed nits.<a href="#appendix-B.22-1.6" class="pilcrow">¶</a>
+</li>
+        </ol>
+</section>
+</section>
+<div id="authors-addresses">
+<section id="appendix-C">
+      <h2 id="name-authors-addresses">
+<a href="#name-authors-addresses" class="section-name selfRef">Authors' Addresses</a>
+      </h2>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Mario Loffredo</span></div>
+<div dir="auto" class="left"><span class="org">IIT-CNR/Registro.it</span></div>
+<div dir="auto" class="left"><span class="street-address">Via Moruzzi,1</span></div>
+<div dir="auto" class="left">
+<span class="postal-code">56124</span> <span class="locality">Pisa</span> </div>
+<div dir="auto" class="left"><span class="country-name">Italy</span></div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:mario.loffredo@iit.cnr.it" class="email">mario.loffredo@iit.cnr.it</a>
+</div>
+<div class="url">
+<span>URI:</span>
+<a href="http://www.iit.cnr.it" class="url">http://www.iit.cnr.it</a>
+</div>
+</address>
+<address class="vcard">
+        <div dir="auto" class="left"><span class="fn nameRole">Gavin Brown</span></div>
+<div dir="auto" class="left"><span class="org">CentralNic Group plc</span></div>
+<div dir="auto" class="left"><span class="street-address">Saddlers House, 44 Gutter Lane</span></div>
+<div dir="auto" class="left"><span class="locality">London</span></div>
+<div dir="auto" class="left"><span class="postal-code">EC2V 6BR</span></div>
+<div dir="auto" class="left"><span class="country-name">United Kingdom</span></div>
+<div class="tel">
+<span>Phone:</span>
+<a href="tel:+44%2020%2033%2088%200600" class="tel">+44 20 33 88 0600</a>
+</div>
+<div class="email">
+<span>Email:</span>
+<a href="mailto:gavin.brown@centralnic.com" class="email">gavin.brown@centralnic.com</a>
+</div>
+<div class="url">
+<span>URI:</span>
+<a href="https://www.centralnic.com" class="url">https://www.centralnic.com</a>
+</div>
+</address>
+</section>
+</div>
+<script>const toc = document.getElementById("toc");
+toc.querySelector("h2").addEventListener("click", e => {
+  toc.classList.toggle("active");
+});
+toc.querySelector("nav").addEventListener("click", e => {
+  toc.classList.remove("active");
+});
+</script>
+</body>
+</html>

--- a/versions/draft-ietf-regext-rdap-jscontact-16.txt
+++ b/versions/draft-ietf-regext-rdap-jscontact-16.txt
@@ -1,0 +1,1400 @@
+
+
+
+
+Registration Protocols Extensions                            M. Loffredo
+Internet-Draft                                       IIT-CNR/Registro.it
+Intended status: Standards Track                                G. Brown
+Expires: 8 December 2023                            CentralNic Group plc
+                                                             6 June 2023
+
+
+    Using JSContact in Registration Data Access Protocol (RDAP) JSON
+                               Responses
+                  draft-ietf-regext-rdap-jscontact-16
+
+Abstract
+
+   This document describes an RDAP extension which represents entity
+   contact information in JSON responses using JSContact.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 8 December 2023.
+
+Copyright Notice
+
+   Copyright (c) 2023 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Revised BSD License text as
+   described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Revised BSD License.
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023                [Page 1]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.1.  Rationale . . . . . . . . . . . . . . . . . . . . . . . .   3
+     1.2.  Conventions Used in This Document . . . . . . . . . . . .   3
+   2.  JSContact . . . . . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  Using JSContact objects in RDAP Responses . . . . . . . . . .   4
+     3.1.  RDAP Query Parameters . . . . . . . . . . . . . . . . . .  10
+   4.  Transition Considerations . . . . . . . . . . . . . . . . . .  10
+     4.1.  RDAP Features Supporting a Transition Process . . . . . .  10
+       4.1.1.  Notices and Link Relationships  . . . . . . . . . . .  10
+       4.1.2.  rdapConformance Property  . . . . . . . . . . . . . .  10
+     4.2.  Transition Procedure  . . . . . . . . . . . . . . . . . .  11
+       4.2.1.  Goals . . . . . . . . . . . . . . . . . . . . . . . .  11
+       4.2.2.  Transition Stages . . . . . . . . . . . . . . . . . .  11
+         4.2.2.1.  Stage 1: only jCard provided  . . . . . . . . . .  11
+         4.2.2.2.  Stage 2: jCard sunset . . . . . . . . . . . . . .  11
+         4.2.2.3.  Stage 3: jCard deprecation  . . . . . . . . . . .  12
+         4.2.2.4.  Length  . . . . . . . . . . . . . . . . . . . . .  13
+   5.  Implementation Status . . . . . . . . . . . . . . . . . . . .  13
+     5.1.  IIT-CNR/Registro.it RDAP Server . . . . . . . . . . . . .  13
+     5.2.  IIT-CNR/Registro.it RDAP Client . . . . . . . . . . . . .  14
+     5.3.  client.rdap.org . . . . . . . . . . . . . . . . . . . . .  14
+     5.4.  CentralNic Registry . . . . . . . . . . . . . . . . . . .  14
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
+     6.1.  RDAP Extensions Registry  . . . . . . . . . . . . . . . .  14
+     6.2.  RDAP JSON Values Registry . . . . . . . . . . . . . . . .  15
+     6.3.  RDAP Reverse Search Mapping Registry  . . . . . . . . . .  16
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  16
+   8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  17
+   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  17
+     9.1.  Normative References  . . . . . . . . . . . . . . . . . .  17
+     9.2.  Informative References  . . . . . . . . . . . . . . . . .  18
+   Appendix A.  jCard-JSContact Mapping  . . . . . . . . . . . . . .  19
+   Appendix B.  Change Log . . . . . . . . . . . . . . . . . . . . .  21
+     B.1.  Change from 00 to 01  . . . . . . . . . . . . . . . . . .  21
+     B.2.  Change from 01 to 02  . . . . . . . . . . . . . . . . . .  22
+     B.3.  Change from 02 to 03  . . . . . . . . . . . . . . . . . .  22
+     B.4.  Change from 03 to 04  . . . . . . . . . . . . . . . . . .  22
+     B.5.  Initial WG version  . . . . . . . . . . . . . . . . . . .  22
+     B.6.  Change from 00 to 01  . . . . . . . . . . . . . . . . . .  22
+     B.7.  Change from 01 to 02  . . . . . . . . . . . . . . . . . .  22
+     B.8.  Change from 02 to 03  . . . . . . . . . . . . . . . . . .  22
+     B.9.  Change from 03 to 04  . . . . . . . . . . . . . . . . . .  23
+     B.10. Change from 04 to 05  . . . . . . . . . . . . . . . . . .  23
+     B.11. Change from 05 to 06  . . . . . . . . . . . . . . . . . .  23
+     B.12. Change from 06 to 07  . . . . . . . . . . . . . . . . . .  23
+     B.13. Change from 07 to 08  . . . . . . . . . . . . . . . . . .  23
+
+
+
+Loffredo & Brown         Expires 8 December 2023                [Page 2]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+     B.14. Change from 08 to 09  . . . . . . . . . . . . . . . . . .  23
+     B.15. Change from 09 to 10  . . . . . . . . . . . . . . . . . .  23
+     B.16. Change from 10 to 11  . . . . . . . . . . . . . . . . . .  24
+     B.17. Change from 11 to 12  . . . . . . . . . . . . . . . . . .  24
+     B.18. Change from 12 to 13  . . . . . . . . . . . . . . . . . .  24
+     B.19. Change from 13 to 14  . . . . . . . . . . . . . . . . . .  24
+     B.20. Change from 14 to 15  . . . . . . . . . . . . . . . . . .  24
+     B.21. Change from 14 to 15  . . . . . . . . . . . . . . . . . .  24
+     B.22. Change from 15 to 16  . . . . . . . . . . . . . . . . . .  24
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  25
+
+1.  Introduction
+
+   This document specifies an extension to the Registration Data Access
+   Protocol (RDAP) that allows RDAP servers to use JSContact
+   [I-D.ietf-calext-jscontact] to represent the contact information
+   associated with entities in RDAP responses, instead of jCard
+   [RFC7095].  It also describes the process by which an RDAP server can
+   transition from jCard to JSContact.  RDAP query and response
+   extensions are defined to facilitate the transition process.
+
+1.1.  Rationale
+
+   According to the feedback from RDAP Pilot Working Group
+   [RDAP-PILOT-WG], a group of RDAP server implementers representing
+   registries and registrars of generic TLDs, the most commonly raised
+   implementation concern, for both servers and client implementers,
+   related to the use of jCard [RFC7095] to represent the contact
+   information associated with entities.  Working Group members reported
+   jCard to be unintuitive, complicated to implement for both clients
+   and servers, and incompatible with best practices for RESTful APIs.
+
+   JSContact [I-D.ietf-calext-jscontact] provides a simpler and more
+   efficient representation for contact information with regard to time
+   and effort saved in processing it.  In addition, similarly to jCard,
+   it provides a means to represent internationalised and unstructured
+   contact information.  Support for internationalised contact
+   information has been recognised being necessary to facilitate the
+   future internationalisation of registration data directory services.
+
+1.2.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023                [Page 3]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   The JSContact specification declares the object type "Card" which
+   represents a single contact card.  To avoid confusion, in the
+   following of this document, the term "JSCard" is used to refer to
+   "JSContact Card".
+
+2.  JSContact
+
+   The JSContact specification defines a data model and JSON
+   representation of contact information that can be used for data
+   storage and exchange in address book or directory applications.  It
+   aims to be an alternative to the vCard data format [RFC6350] and to
+   be unambiguous, extendable and simple to process.  In contrast with
+   jCard, it is not a direct mapping from the vCard data model and
+   expands semantics where appropriate.
+
+   JSCard differs from jCard in that it:
+
+   *  follows an object-oriented rather than array-oriented approach;
+   *  is simple to process;
+   *  requires no extra work in serialization/deserialization from/to a
+      data model;
+   *  includes no "jagged" arrays;
+   *  prefers maps rather than arrays to implement collections.
+
+   [I-D.ietf-calext-jscontact-vcard] provides informational guidance on
+   the conversion of jCard into JSCard, and vice versa.  Appendix A
+   shows JSContact counterparts for the most commonly used jCard
+   properties in an RDAP response.
+
+3.  Using JSContact objects in RDAP Responses
+
+   Entity objects in RDAP responses MAY include a "jscard" property
+   whose value is a JSCard object instead of the "vCardArray" property
+   defined in [RFC9083].
+
+   Servers returning the "jscard" property in their response MUST
+   include "jscard" in the "rdapConformance" array.
+
+   Since most of the JSCard collections are represented as maps, map
+   keys must be defined.  A JSContact map key MUST comply with the
+   definition of the Id type.  To aid interoperability, RDAP providers
+   MUST use the following Id values related to string values and labels
+   defined in [RFC5733]:
+
+   *  "org" in the "organizations" map when there is a single
+      <contact:org> element.  If both internationalised and localized
+      forms exist, the key MUST be used for the internationalised form;
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023                [Page 4]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   *  "addr" in the "addresses" map when there is a single
+      <contact:addr> element.  If both internationalised and localized
+      forms exist, the key MUST be used for the internationalised form;
+   *  "email" in the "emails" map when there is a single <contact:email>
+      element;
+   *  "voice" in the "phones" map for the <contact:voice> element;
+   *  "fax" in the "phones" map for the <contact:fax> element.
+
+   The information needed to register the JSContact Id values in the
+   "RDAP JSON Values" registry [RFC9083] is described in Section 6.2.
+
+   If present, the localized versions of name, organization and postal
+   address MUST be added to the "localizations" map.  With reference to
+   the defintion of localization in [I-D.ietf-calext-jscontact], an RDAP
+   response with JSContact content MUST expand all localizations (i.e. a
+   patch key using the syntax "{key1}/{key2}/.../{keyN}" is not
+   allowed).  The following is an elided example of an RDAP entity
+   lookup response including a JSCard object that presents a localized
+   postal address (See PDF for non-ASCII character string).
+
+   ...
+   "jscard": {
+     "@type" : "Card",
+     "@version" : "1.0",
+     "uid" : "7812cafe-336e-5969-988b-ad68f78ae90f",
+     "language" : "en",
+     "fullName" : "Vasya Pupkin",
+     "organizations" : {
+       "org" : {
+         "name" : "My Company"
+       }
+     },
+     "addresses" : {
+       "addr" : {
+         "street" : [ {
+           "kind" : "name",
+           "value" : "1 Street"
+         }, {
+           "kind" : "postOfficeBox",
+           "value" : "01001"
+         } ],
+         "locality" : "Kyiv",
+         "countryCode" : "UA"
+       }
+     },
+     "localizations" : {
+       "ua" : {
+         "addresses": {
+
+
+
+Loffredo & Brown         Expires 8 December 2023                [Page 5]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+           "addr" : {
+             "street" : [ {
+               "kind" : "name",
+               "value" : "1, Улица"
+             }, {
+               "kind" : "postOfficeBox",
+               "value" : "01001"
+             } ],
+             "locality" : "Киев",
+             "countryCode" : "UA"
+           }
+         },
+         "fullName" : "Вася Пупкин",
+         "organizations": {
+           "org" : {
+             "name" : "Моя Компания"
+           }
+         }
+       }
+     }
+   }
+   ...
+
+          Figure 1: Example of handling localizations in JSContact
+
+   Implementers MAY use different mapping schemes to define keys for
+   additional entries of the aforementioned maps or others.  For
+   example, a mapping scheme may consist in using a trivial sequential
+   number (e.g. "url-1", "url-2", etc.)
+
+   The following is an example of an RDAP entity including a JSCard
+   object that has been converted from the example in section 5.1 of
+   [RFC9083].
+
+      {
+         "rdapConformance": [
+            "rdap_level_0",
+            "jscard"
+         ],
+         "objectClassName" : "entity",
+         "handle":"XXXX",
+         "jscard":{
+           "@type": "Card",
+           "@version": "1.0",
+           "uid": "74b64df3-2d60-56b4-9df3-8594886f4456",
+           "language" : "en",
+           "fullName": "Joe User" ,
+           "name": {
+
+
+
+Loffredo & Brown         Expires 8 December 2023                [Page 6]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+             "components": [
+               {
+                 "type": "surname",
+                 "value": "User"
+               },
+               {
+                 "type": "given",
+                 "value": "Joe"
+               },
+               {
+                 "type": "suffix",
+                 "value": "ing. jr"
+               },
+               {
+                 "type": "suffix",
+                 "value": "M.Sc."
+               }
+             ]
+           },
+           "kind": "individual",
+           "preferredLanguages": {
+             "fr": {
+               "pref": 1
+             },
+             "en": {
+               "pref": 2
+             }
+           },
+           "organizations": {
+             "org": {
+               "name": "Example"
+             }
+           },
+           "titles": {
+             "title": {
+               "kind": "title",
+               "name": "Research Scientist"
+             },
+             "role": {
+               "kind": "role",
+               "name": "Project Lead"
+             }
+           },
+           "addresses": {
+             "addr": {
+               "contexts": {
+                 "work": true
+               },
+
+
+
+Loffredo & Brown         Expires 8 December 2023                [Page 7]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+               "street": [
+                 {
+                   "kind": "name",
+                   "value": "4321 Rue Somewhere"
+                 },
+                 {
+                   "kind": "extension",
+                   "value": "Suite 1234"
+                 }
+               ],
+               "locality": "Quebec",
+               "region": "QC",
+               "postcode": "G1V 2M2",
+               "country": "Canada",
+               "countryCode": "CA",
+               "coordinates": "geo:46.772673,-71.282945",
+               "timeZone": "Etc/GMT+5"
+             },
+             "home": {
+               "contexts": {
+                 "private": true
+               },
+               "fullAddress": "123 Maple Ave\nVancouver\nBC\n1239\n"
+             }
+           },
+           "phones": {
+             "voice" : {
+               "contexts": {
+                 "work": true
+               },
+               "features": {
+                  "voice": true,
+                  "mobile": true,
+                  "video": true,
+                  "text": true
+               },
+               "pref": 1,
+               "number": "tel:+1-555-555-1234;ext=102"
+             }
+           },
+           "emails": {
+             "email": {
+               "contexts": {
+                 "work": true
+               },
+               "address": "joe.user@example.com"
+             }
+           },
+
+
+
+Loffredo & Brown         Expires 8 December 2023                [Page 8]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+           "cryptoKeys": {
+             "contexts": {
+               "work": true
+             },
+             "uri": "https://www.example.com/joe.user/joe.asc"
+           },
+           "links": {
+             "contexts": {
+               "private": true
+             },
+             "uri": "https://example.org"
+           }
+         },
+         "roles":[ "registrar" ],
+         "publicIds":[
+           {
+             "type":"IANA Registrar ID",
+             "identifier":"1"
+           }
+         ],
+         "remarks":[
+           {
+             "description":[
+               "She sells sea shells down by the sea shore.",
+               "Originally written by Terry Sullivan."
+             ]
+           }
+         ],
+         "links":[
+           {
+             "value":"https://example.com/entity/XXXX",
+             "rel":"self",
+             "href":"https://example.com/entity/XXXX",
+             "type" : "application/rdap+json"
+           }
+         ],
+         "events":[
+           {
+             "eventAction":"registration",
+             "eventDate":"1990-12-31T23:59:59Z"
+           }
+         ],
+         "asEventActor":[
+           {
+             "eventAction":"last changed",
+             "eventDate":"1991-12-31T23:59:59Z"
+           }
+         ]
+
+
+
+Loffredo & Brown         Expires 8 December 2023                [Page 9]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+      }
+
+           Figure 2: Example of using JSContact in RDAP response
+
+   The use of JSContact updates the mappings of two reverse search
+   properties, namely "fn" and "email", defined in
+   [I-D.ietf-regext-rdap-reverse-search].  Such new mappings are
+   registered in the Reverse Search Mapping registry as described in
+   Section 6.3.
+
+3.1.  RDAP Query Parameters
+
+   One new query parameter is defined for the purpose of this document.
+
+   The parameter is an OPTIONAL extension of queries defined in
+   [RFC9082] as well as any RDAP query described by a future document
+   whose response includes contact information.  It is as follows:
+
+   "jscard": a boolean value that allows a client to request the
+   "jscard" property in the RDAP response;
+
+   This parameter is further explained in Section 4.2.2.2.
+
+4.  Transition Considerations
+
+4.1.  RDAP Features Supporting a Transition Process
+
+4.1.1.  Notices and Link Relationships
+
+   RDAP allows servers to communicate service information to clients
+   through notices.  According to Section 4.3 of [RFC9083], an RDAP
+   response may contain one or more notice objects.  Each notice may
+   include a set of link objects, which can be used to provide clients
+   with references and documentation.  These link objects may have a
+   "rel" property which defines the relationship type, as described in
+   [RFC8288], Section 4.  The transition process outlined in this
+   document uses two link relation types, namely "related" and
+   "alternate", described in [RFC8288].
+
+4.1.2.  rdapConformance Property
+
+   The information about the specifications used in the construction of
+   the response is also described by the strings which appear in the
+   "rdapConformance" property of the RDAP response.
+
+
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 10]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+4.2.  Transition Procedure
+
+   The principles of the procedure for jCard to JSCard transition are
+   based on the best practices in [API-DEPRECATION].
+
+   The procedure consists of three contiguous stages.  During the
+   procedure, the presence of "jscard" tag in the rdapConformance array
+   indicates that JSCard is returned instead of jCard.  The date and
+   time format used to notify clients about the stages of this procedure
+   is defined in [RFC3339].
+
+4.2.1.  Goals
+
+   The procedure described in this document aims to achieve the
+   following goals:
+
+   *  only one contact representation would be included in the response;
+   *  the response would always be compliant to [RFC9083] because:
+      -  being the "jscard" property a response extension, its presence
+         would be signaled by the "jscard" conformance tag;
+      -  being "vcardArray" property optional in a response, its absence
+         would be allowed;
+   *  clients would be informed about the transition timeline;
+   *  the backward compatibility would be guaranteed throughout the
+      transition;
+   *  servers and clients could execute their transitions independently.
+
+4.2.2.  Transition Stages
+
+4.2.2.1.  Stage 1: only jCard provided
+
+   This stage corresponds to providing jCard as the default contact card
+   [RFC9083].  The RDAP server is not able to provide an alternate
+   format for the contact card.  The rdapConformance array MUST NOT
+   contain the "jscard" tag.
+
+4.2.2.2.  Stage 2: jCard sunset
+
+   During this stage, the server uses jCard by default, but the RDAP
+   server will return JSCard if the client sets the query parameter
+   "jscard" to 1/true/yes.  The rdapConformance array MUST contain the
+   "jscard" tag if JSCard is returned.
+
+   From this stage on, the RDAP server MUST include the "jscard" tag in
+   the rdapConformance array of the help response to signal clients that
+   JSCard can be returned instead of jCard.
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 11]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   If JSCard is not requested, the RDAP server SHOULD include a notice
+   titled "jCard sunset end".  Such a notice includes a description
+   reporting the jCard sunset end date and time and two OPTIONAL links:
+
+   *  "related": a link to a URI-identified resource documenting the
+      transition procedure;
+   *  "alternate": a link to an alternate result view identified by the
+      current query string plus the parameter "jscard" set to 1/true/yes
+      (Figure 3).
+
+   "notices": [
+     {
+       "title": "jCard sunset end",
+       "description": ["2022-12-31T23:59:59Z"],
+       "links": [{
+           "value": "https://example.net/entity/XXXX",
+           "rel": "related",
+           "type": "text/html",
+           "href": "https://www.example.com/jcard_deprecation.html"
+         },
+         {
+           "value": "https://example.net/entity/XXXX",
+           "rel": "alternate",
+           "type": "application/rdap+json",
+           "href": " https://example.net/entity/XXXX?jscard=1"
+         }
+       ]
+     }
+   ]
+
+               Figure 3: jCard sunset - JSCard not requested
+
+4.2.2.3.  Stage 3: jCard deprecation
+
+   This stage corresponds to providing JSCard as default contact card.
+   The rdapConformance array always contains "jscard" tag.  The RDAP
+   server doesn't include any notice about the jCard deprecation
+   process.  The "jscard" query parameter MUST be ignored.
+
+   FOR DISCUSSION: should server signal the end of the transition by
+   including the "jcard_deprecated" value in the rdapConformance array ?
+   Would its usage be compliant with the rdapConformance definition in
+   RFC 9083 ?
+
+
+
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 12]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+4.2.2.4.  Length
+
+   The length of the jCard sunset period is not fixed by this
+   specification.  Best practices in REST API deprecation suggest that,
+   depending on the deprecated API's reach, user base and service
+   offering, a convenient time could be anywhere between 3 - 8 months.
+   Anyway, RDAP providers are RECOMMENDED to monitor the server log to
+   figure out whether the declared time need to be changed to meet
+   client requirements.
+
+5.  Implementation Status
+
+   NOTE: Please remove this section and the reference to RFC 7942 prior
+   to publication as an RFC.
+
+   This section records the status of known implementations of the
+   protocol defined by this specification at the time of posting of this
+   Internet-Draft, and is based on a proposal described in RFC 7942
+   [RFC7942].  The description of implementations in this section is
+   intended to assist the IETF in its decision processes in progressing
+   drafts to RFCs.  Please note that the listing of any individual
+   implementation here does not imply endorsement by the IETF.
+   Furthermore, no effort has been spent to verify the information
+   presented here that was supplied by IETF contributors.  This is not
+   intended as, and must not be construed to be, a catalog of available
+   implementations or their features.  Readers are advised to note that
+   other implementations may exist.
+
+   According to RFC 7942, "this will allow reviewers and working groups
+   to assign due consideration to documents that have the benefit of
+   running code, which may serve as evidence of valuable experimentation
+   and feedback that have made the implemented protocols more mature.
+   It is up to the individual working groups to use this information as
+   they see fit".
+
+5.1.  IIT-CNR/Registro.it RDAP Server
+
+   *  Responsible Organization: Institute of Informatics and Telematics
+      of National Research Council (IIT-CNR)/Registro.it
+   *  Location: https://rdap.pubtest.nic.it/
+      (https://rdap.pubtest.nic.it/domain/nic.it?jscard=1)
+   *  Description: This implementation includes support for RDAP queries
+      using data from the public test environment of .it ccTLD.
+   *  Level of Maturity: This is an "alpha" test implementation.
+   *  Coverage: This implementation includes all of the features
+      described in this specification.
+   *  Contact Information: Mario Loffredo, mario.loffredo@iit.cnr.it
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 13]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+5.2.  IIT-CNR/Registro.it RDAP Client
+
+   *  Responsible Organization: Institute of Informatics and Telematics
+      of National Research Council (IIT-CNR)/Registro.it
+   *  Location: https://web-rdap.pubtest.nic.it/
+   *  Description: This is a Javascript web-based RDAP client.  RDAP
+      responses are retrieved from RDAP servers by the browser, parsed
+      into an HTML representation, and displayed in a format improving
+      the user experience.  RDAP responses containing JSCard objects are
+      handled identically to those containing jCard objects.  Raw
+      versions of RDAP responses including either jCard or JSCard
+      objects are provided.
+   *  Level of Maturity: This is an "alpha" test implementation.
+   *  Coverage: This implementation includes all of the features
+      described in this specification.
+   *  Contact Information: Francesco Donini, francesco.donini@iit.cnr.it
+
+5.3.  client.rdap.org
+
+   *  Location: https://client.rdap.org/
+   *  Description: This is a web-based "single page" RDAP client.  RDAP
+      responses are retrieved from RDAP servers by the browser, and
+      parsed into an HTML representation.  RDAP responses containing
+      JSCard objects are handled identically to those containing jCard
+      objects.
+   *  Level of Maturity: This is an "alpha" test implementation.
+   *  Coverage: This implementation implements client support for
+      parsing JSCard objects in RDAP responses.
+   *  Contact Information: Gavin Brown, feedback@rdap.org
+
+5.4.  CentralNic Registry
+
+   *  Responsible Organization: CentralNic Group PLC
+   *  Location: https://rdap.centralnic.com/{tld}
+   *  Description: This server is the product RDAP service for all top-
+      level domains on the CentralNic registry platform.
+   *  Level of Maturity: Production quality.
+   *  Coverage: This implementation includes all of the features
+      described in this specification.
+   *  Contact Information: support@centralnic.com
+
+6.  IANA Considerations
+
+6.1.  RDAP Extensions Registry
+
+   IANA is requested to register the following values in the RDAP
+   Extensions Registry:
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 14]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   *  Extension identifier: jscard
+   *  Registry operator: Any
+   *  Published specification: This document.
+   *  Contact: IETF <iesg@ietf.org>
+   *  Intended usage: This extension prefix identifier is used for the
+      "jscard" member returned in the JSON response
+      [I-D.ietf-calext-jscontact].
+
+6.2.  RDAP JSON Values Registry
+
+   With regard to the fields of the "RDAP JSON Values" registry
+   [RFC9083], the "JSContact Id Value" type SHALL be used to register
+   the RDAP values for the JSContact Id type as defined in Section 3.
+
+   IANA is requested to register the following values in the "RDAP JSON
+   Values" registry:
+
+   Value:  org
+   Type:  JSContact Id Value
+   Description:  The key in the JSContact "organizations" map
+      identifiying the contact organization.
+   Registrant Name:  IESG
+   Registrant Contact Information:  iesg@ietf.org
+   Reference:  This document
+
+   Value:  addr
+   Type:  JSContact Id Value
+   Description:  The key in the JSContact "addresses" map identifiying
+      the unique or preferred contact postal address.
+   Registrant Name:  IESG
+   Registrant Contact Information:  iesg@ietf.org
+   Reference:  This document
+
+   Value:  email
+   Type:  JSContact Id Value
+   Description:  The key in the JSContact "emails" map identifiying the
+      unique or preferred contact email address.
+   Registrant Name:  IESG
+   Registrant Contact Information:  iesg@ietf.org
+   Reference:  This document
+
+   Value:  voice
+   Type:  JSContact Id Value
+   Description:  The key in the JSContact "phones" map identifiying the
+      unique or preferred contact voice number.
+   Registrant Name:  IESG
+   Registrant Contact Information:  iesg@ietf.org
+   Reference:  This document
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 15]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   Value:  fax
+   Type:  JSContact Id Value
+   Description:  The key in the JSContact "phones" map identifiying the
+      unique or preferred contact fax number.
+   Registrant Name:  IESG
+   Registrant Contact Information:  iesg@ietf.org
+   Reference:  This document
+
+6.3.  RDAP Reverse Search Mapping Registry
+
+   IANA is requested to register the following entries in the the "RDAP
+   Reverse Search Mapping" registry
+   [I-D.ietf-regext-rdap-reverse-search]:
+
+   Searchable Resource Type:  domains, nameservers, entities
+   Related Resource Type:  entity
+   Property:  fn
+   Property Path:  $.entities[*].jscard.[fullName,localizations.*.fullNa
+      me]
+   Registrant Name:  IESG
+   Registrant Contact Information:  iesg@ietf.org
+   Reference:  This document
+
+   Searchable Resource Type:  domains, nameservers, entities
+   Related Resource Type:  entity
+   Property:  email
+   Property Path:  $.entities[*].jscard.emails.email.address
+   Registrant Name:  IESG
+   Registrant Contact Information:  iesg@ietf.org
+   Reference:  This document
+
+7.  Security Considerations
+
+   Unlike what happens for the "fn" property in jCard, the only
+   mandatory property in JSContact, namely "uid", is not a sensitive
+   information.  Nevertheless, RDAP operators can redact it to prevent
+   results from being correlated.  Hence, with reference to what is
+   described in [I-D.ietf-regext-rdap-redacted], a redaction method must
+   be selected based on the "uid" format.
+
+
+
+
+
+
+
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 16]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   If "uid" is represented as a URN in the uuid namespace, the most
+   appropriate choice is using the "Replacement Value" method along with
+   the nil UUID as replacing value.  If it is provided in the free-text
+   format, the "Empty Value" method should be preferred.  Otherwise, an
+   URI value can be redacted by using any of the two methods above.  For
+   example, the URL of the RDAP entity corresponding to the contact
+   (e.g. "https://example.com/rdap/entity/XYZ12345") can be redacted by
+   replacing the entity handle with a fixed literal (e.g
+   "https://example.com/rdap/entity/XXXXX").
+
+8.  Acknowledgements
+
+   The authors would like to acknowledge the following individuals for
+   their contributions to this document: Jasdip Singh, Andrew Newton,
+   Marc Blanchet, Rick Wilhelm and Francesco Donini.
+
+9.  References
+
+9.1.  Normative References
+
+   [I-D.ietf-calext-jscontact]
+              Stepanek, R. and M. Loffredo, "JSContact: A JSON
+              representation of contact data", Work in Progress,
+              Internet-Draft, draft-ietf-calext-jscontact-10, 19 April
+              2023, <https://datatracker.ietf.org/doc/html/draft-ietf-
+              calext-jscontact-10>.
+
+   [I-D.ietf-calext-jscontact-vcard]
+              Loffredo, M. and R. Stepanek, "JSContact: Converting from
+              and to vCard", Work in Progress, Internet-Draft, draft-
+              ietf-calext-jscontact-vcard-09, 2 June 2023,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-calext-
+              jscontact-vcard-09>.
+
+   [I-D.ietf-regext-rdap-reverse-search]
+              Loffredo, M. and M. Martinelli, "Registration Data Access
+              Protocol (RDAP) Reverse Search", Work in Progress,
+              Internet-Draft, draft-ietf-regext-rdap-reverse-search-22,
+              2 May 2023, <https://datatracker.ietf.org/doc/html/draft-
+              ietf-regext-rdap-reverse-search-22>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 17]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   [RFC3339]  Klyne, G. and C. Newman, "Date and Time on the Internet:
+              Timestamps", RFC 3339, DOI 10.17487/RFC3339, July 2002,
+              <https://www.rfc-editor.org/info/rfc3339>.
+
+   [RFC5733]  Hollenbeck, S., "Extensible Provisioning Protocol (EPP)
+              Contact Mapping", STD 69, RFC 5733, DOI 10.17487/RFC5733,
+              August 2009, <https://www.rfc-editor.org/info/rfc5733>.
+
+   [RFC6350]  Perreault, S., "vCard Format Specification", RFC 6350,
+              DOI 10.17487/RFC6350, August 2011,
+              <https://www.rfc-editor.org/info/rfc6350>.
+
+   [RFC7095]  Kewisch, P., "jCard: The JSON Format for vCard", RFC 7095,
+              DOI 10.17487/RFC7095, January 2014,
+              <https://www.rfc-editor.org/info/rfc7095>.
+
+   [RFC7942]  Sheffer, Y. and A. Farrel, "Improving Awareness of Running
+              Code: The Implementation Status Section", BCP 205,
+              RFC 7942, DOI 10.17487/RFC7942, July 2016,
+              <https://www.rfc-editor.org/info/rfc7942>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC8288]  Nottingham, M., "Web Linking", RFC 8288,
+              DOI 10.17487/RFC8288, October 2017,
+              <https://www.rfc-editor.org/info/rfc8288>.
+
+   [RFC9082]  Hollenbeck, S. and A. Newton, "Registration Data Access
+              Protocol (RDAP) Query Format", STD 95, RFC 9082,
+              DOI 10.17487/RFC9082, June 2021,
+              <https://www.rfc-editor.org/info/rfc9082>.
+
+   [RFC9083]  Hollenbeck, S. and A. Newton, "JSON Responses for the
+              Registration Data Access Protocol (RDAP)", STD 95,
+              RFC 9083, DOI 10.17487/RFC9083, June 2021,
+              <https://www.rfc-editor.org/info/rfc9083>.
+
+9.2.  Informative References
+
+   [API-DEPRECATION]
+              Sandoval, K., "How to Smartly Sunset and Deprecate APIs",
+              August 2019, <https://web.archive.org/web/20200417084255/
+              https://nordicapis.com/how-to-smartly-sunset-and-
+              deprecate-apis/>.
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 18]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   [I-D.ietf-jsonpath-base]
+              Gössner, S., Normington, G., and C. Bormann, "JSONPath:
+              Query expressions for JSON", Work in Progress, Internet-
+              Draft, draft-ietf-jsonpath-base-13, 15 April 2023,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-
+              jsonpath-base-13>.
+
+   [I-D.ietf-regext-rdap-redacted]
+              Gould, J., Smith, D., Kolker, J., and R. Carney, "Redacted
+              Fields in the Registration Data Access Protocol (RDAP)
+              Response", Work in Progress, Internet-Draft, draft-ietf-
+              regext-rdap-redacted-12, 25 May 2023,
+              <https://datatracker.ietf.org/doc/html/draft-ietf-regext-
+              rdap-redacted-12>.
+
+   [RDAP-PILOT-WG]
+              ICANN RDAP Pilot WG, "RDAP Pilot Report", April 2019,
+              <https://www.icann.org/en/system/files/files/rdap-pilot-
+              report-25apr19-en.pdf>.
+
+   [RFC8605]  Hollenbeck, S. and R. Carney, "vCard Format Extensions:
+              ICANN Extensions for the Registration Data Access Protocol
+              (RDAP)", RFC 8605, DOI 10.17487/RFC8605, May 2019,
+              <https://www.rfc-editor.org/info/rfc8605>.
+
+Appendix A.  jCard-JSContact Mapping
+
+   Provided that the keys defined in Section 3 are used for the
+   JSContact maps, the mapping between the most commonly used jCard
+   properties in an RDAP response and their JSContact counterparts is
+   shown in the following.  The mapping is done through the use of
+   JSONPath expressions [I-D.ietf-jsonpath-base].
+
+   jCard property:  fn
+   Reference:  Section 6.2.1 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[0]=='fn')][3]
+   JSContact property:  fullName
+   Reference:  Section 2.2.1 of [I-D.ietf-calext-jscontact]
+   Path:  $..jscard.[fullName,localizations.*.fullName]
+
+   jCard property:  org
+   Reference:  Section 6.6.4 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[0]=='org')][3]
+   JSContact property:  Organization.name
+   Reference:  Section 2.2.4 of [I-D.ietf-calext-jscontact]
+   Path:
+      $..jscard.[organizations.org.name,localizations.*.organizations.or
+      g.name]
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 19]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   jCard property:  tel with type="voice"
+   Reference:  Section 6.4.1 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[1].type=='voice')][3]
+   JSContact property:  Phone.number
+   Reference:  Section 2.3.3 of [I-D.ietf-calext-jscontact]
+   Path:  $..jscard.phones.voice.number
+
+   jCard property:  tel with type="fax"
+   Reference:  Section 6.4.1 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[1].type=='fax')][3]
+   JSContact property:  Phone.number
+   Reference:  Section 2.3.3 of [I-D.ietf-calext-jscontact]
+   Path:  $..jscard.phones.fax.number
+
+   jCard property:  email
+   Reference:  Section 6.4.2 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[0]=='email')][3]
+   JSContact property:  Email.address
+   Reference:  Section 2.3.1 of [I-D.ietf-calext-jscontact]
+   Path:
+      $..jscard.[emails.email.address,localizations.*.emails.email.addre
+      ss]
+
+   jCard property:  "post office box" component of adr
+   Reference:  Section 6.3.1 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[0]=='adr')][3][1]
+   JSContact property:  "postOfficeBox" StreetComponent of
+      Address.street
+   Reference:  Section 2.5.1 of [I-D.ietf-calext-jscontact]
+   Path:
+      $..jscard.[addresses.addr.street[?(@.type=='postOfficeBox')].value
+      ,localizations.*.addresses.addr.street[?(@.type=='postOfficeBox')]
+      .value]
+
+   jCard property:  "street address" component of adr
+   Reference:  Section 6.3.1 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[0]=='adr')][3][2]
+   JSContact property:  "name" StreetComponent of Address.street
+   Reference:  Section 2.5.1 of [I-D.ietf-calext-jscontact]
+   Path:
+      $..jscard.[addresses.addr.street[?(@.type=='name')].value,localiza
+      tions.*.addresses.addr.street[?(@.type=='name')].value]
+
+   jCard property:  "locality" component of adr
+   Reference:  Section 6.3.1 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[0]=='adr')][3][3]
+   JSContact property:  Address.locality
+   Reference:  Section 2.5.1 of [I-D.ietf-calext-jscontact]
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 20]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   Path:
+      $..jscard.[addresses.addr.locality,localizations.*.addresses.addr.
+      locality]
+
+   jCard property:  "region" component of adr
+   Reference:  Section 6.3.1 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[0]=='adr')][3][4]
+   JSContact property:  Address.region
+   Reference:  Section 2.5.1 of [I-D.ietf-calext-jscontact]
+   Path:
+      $..jscard.[addresses.addr.region,localizations.*.addresses.addr.re
+      gion]
+
+   jCard property:  "postal code" component of adr
+   Reference:  Section 6.3.1 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[0]=='adr')][3][5]
+   JSContact property:  Address.postcode
+   Reference:  Section 2.5.1 of [I-D.ietf-calext-jscontact]
+   Path:
+      $..jscard.[addresses.addr.postcode,localizations.*.addresses.addr.
+      postcode]
+
+   jCard property:  "country name" component of adr
+   Reference:  Section 6.3.1 of [RFC6350]
+   Path:  $..vcardArray[1][?(@[0]=='adr')][3][6]
+   JSContact property:  Address.country
+   Reference:  Section 2.5.1 of [I-D.ietf-calext-jscontact]
+   Path:
+      $..jscard.[addresses.addr.country,localizations.*.addresses.addr.c
+      ountry]
+
+   jCard property:  "cc" parameter of adr
+   Reference:  Section 3.1 of [RFC8605]
+   Path:  $..vcardArray[1][?(@[0]=='adr')][1].cc
+   JSContact property:  Address.countryCode
+   Reference:  Section 2.5.1 of [I-D.ietf-calext-jscontact]
+   Path:
+      $..jscard.[addresses.addr.countryCode,localizations.*.addresses.ad
+      dr.countryCode]
+
+Appendix B.  Change Log
+
+B.1.  Change from 00 to 01
+
+   1.   Changed category from "Best Current Practice" to "Standards
+        Track"
+   2.   Replaced the example of Figure 2
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 21]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   3.   Changed the title of the "Migration from JCard to JSCard"
+        section to "Transition Considerations"
+   4.   Added Section 3.1
+   5.   Updated Section 6
+   6.   Updated Section 7
+   7.   Rearranged the description of stage 1 in Section 4.2.2
+   8.   Changed the names of the transition stages 1 and 2
+   9.   Corrected examples
+   10.  Changed the rdapConformance tag "jscard_level_0" to "jscard"
+   11.  Removed the "Best Practices for deprecating a REST API features"
+        section,but added a useful reference.
+
+B.2.  Change from 01 to 02
+
+   1.  Removed the sentence "which cannot be represented using jCard" in
+       Section 1.1.
+
+B.3.  Change from 02 to 03
+
+   1.  Updated section "Conventions Used in This Document".
+   2.  Updated the contact in "IANA Considerations" section.
+   3.  Changed the reference draft-loffredo-calext-jscontact-vcard to
+       draft-ietf-calext-jscontact-vcard.
+   4.  Added reference to RFC8174.
+   5.  Other minor edits.
+
+B.4.  Change from 03 to 04
+
+   1.  Updated the reference draft-dalal-deprecation-header to draft-
+       ietf-httpapi-deprecation-header.
+
+B.5.  Initial WG version
+
+   1.  Ported from draft-loffredo-regext-rdap-jcard-deprecation-04
+       renamed to draft-ietf-regext-rdap-jscontact-00.
+
+B.6.  Change from 00 to 01
+
+   1.  Updated Section 3 and Figure 2.
+
+B.7.  Change from 01 to 02
+
+   1.  Updated Section 2 and Figure 2.
+
+B.8.  Change from 02 to 03
+
+   1.  Replaced references to obsolete RFC7482 and RFC7483 with RFC9082
+       and RFC9083.
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 22]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+   2.  Updated Section 3 and Figure 2.
+
+B.9.  Change from 03 to 04
+
+   1.  Changed the references to Internet Drafts.
+   2.  Added an example showing how localizations are treated in
+       JSContact.
+   3.  Changed the position of section "Goals" in Section 4.2.
+   4.  Added three more implementations to Section 5.
+   5.  Changed the rdapConformance tag "jscard" to "jscard_0"
+   6.  Added clarifications addressing the feedback provided by Jasdip
+       Singh about version -03.
+   7.  Added Section 8.
+   8.  Other minor edits.
+
+B.10.  Change from 04 to 05
+
+   1.  Updated Figure 2 to make it compliant with draft-ietf-jmap-
+       jscontact-09.
+
+B.11.  Change from 05 to 06
+
+   1.  Reviewed the notices presented in stages.
+
+B.12.  Change from 06 to 07
+
+   1.  Corrected the JSON Pointer expressions in Figure 1.
+   2.  Other minor edits.
+
+B.13.  Change from 07 to 08
+
+   1.  Corrected a nit in Figure 1.
+   2.  Removed the reference to draft-ietf-httpapi-deprecation-header.
+   3.  Replaced the "deprecation" link relation type with "related".
+   4.  Moved the references to JSContact drafts to the "Normative
+       References" section.
+
+B.14.  Change from 08 to 09
+
+   1.  Updated the references to JSContact drafts due to the transfer
+       from JMAP to CalExt.
+
+B.15.  Change from 09 to 10
+
+   1.  Updated Figure 2 to make it compliant with draft-ietf-calext-
+       jscontact-02.
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 23]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+B.16.  Change from 10 to 11
+
+   1.  Added Appendix "jCard-JSContact Mapping".
+
+B.17.  Change from 11 to 12
+
+   1.  Renamed the "jscard" property to "jscard_0".
+   2.  Corrected JSONPath expressions in Appendix A.
+
+B.18.  Change from 12 to 13
+
+   1.  Reverted the names of response extension, the rdapConformance tag
+       and extension identifier from "jscard_0" to "jscard".
+   2.  Corrected Figure 1 by removing initial '/' character from
+       JSONPath notations related to localizations.
+
+B.19.  Change from 13 to 14
+
+   1.  Corrected Figure 2 by replacing "online" property with
+       "cryptoKeys" and "links" properties.
+
+B.20.  Change from 14 to 15
+
+   1.  Corrected Figure 1, Figure 2 and Appendix A to make them
+       compliant with draft-ietf-calext-jscontact-06.
+   2.  Removed mention of JSContact CardGroup object.
+   3.  Renamed and changed Section 3.
+   4.  Added Section 6.2.
+
+B.21.  Change from 14 to 15
+
+   1.  Corrected Figure 1, Figure 2 and Appendix A to make them
+       compliant with draft-ietf-calext-jscontact-06.
+   2.  Removed mention of JSContact CardGroup object.
+   3.  Renamed and changed Section 3.
+   4.  Added Section 6.2.
+
+B.22.  Change from 15 to 16
+
+   1.  Replaced JSContact "type" with "kind" in figures.
+   2.  Removed "jCard deprecation" stage and "jcard" query parameter.
+   3.  Renamed "jCard deprecated" stage into "jCard deprecation".
+   4.  Rephrased Section 7.
+   5.  Corrected JSContact examples based on draft-ietf-calext-
+       jscontact-11.
+   6.  Fixed nits.
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 24]
+
+Internet-Draft           Using JSContact in RDAP               June 2023
+
+
+Authors' Addresses
+
+   Mario Loffredo
+   IIT-CNR/Registro.it
+   Via Moruzzi,1
+   56124 Pisa
+   Italy
+   Email: mario.loffredo@iit.cnr.it
+   URI:   http://www.iit.cnr.it
+
+
+   Gavin Brown
+   CentralNic Group plc
+   Saddlers House, 44 Gutter Lane
+   London
+   EC2V 6BR
+   United Kingdom
+   Phone: +44 20 33 88 0600
+   Email: gavin.brown@centralnic.com
+   URI:   https://www.centralnic.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Loffredo & Brown         Expires 8 December 2023               [Page 25]

--- a/versions/draft-ietf-regext-rdap-jscontact-16.xml
+++ b/versions/draft-ietf-regext-rdap-jscontact-16.xml
@@ -1,0 +1,1024 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE rfc
+[
+  <!ENTITY RFC2119 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml'>
+  <!ENTITY RFC3339 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.3339.xml'>
+  <!ENTITY RFC5733 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.5733.xml'>
+  <!ENTITY RFC6350 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.6350.xml'>
+  <!ENTITY RFC7095 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7095.xml'>
+  <!ENTITY RFC8605 PUBLIC ''
+    'http://xml.resource.org/public/rfc/bibxml/reference.RFC.8605.xml'>
+  <!ENTITY RFC9082 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.9082.xml'>
+  <!ENTITY RFC9083 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.9083.xml'>
+  <!ENTITY RFC7942 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7942.xml'>
+  <!ENTITY RFC8174 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.8174.xml'>
+  <!ENTITY RFC8288 PUBLIC ''
+   'http://xml.resource.org/public/rfc/bibxml/reference.RFC.8288.xml'>
+  <!ENTITY I-D.ietf-calext-jscontact PUBLIC ''
+   'https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-calext-jscontact.xml'>
+  <!ENTITY I-D.ietf-calext-jscontact-vcard PUBLIC ''
+   'https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-calext-jscontact-vcard.xml'>
+  <!ENTITY I-D.ietf-regext-rdap-redacted PUBLIC ''
+   'https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-regext-rdap-redacted.xml'>
+  <!ENTITY I-D.ietf-regext-rdap-reverse-search PUBLIC ''
+   'https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-regext-rdap-reverse-search.xml'>
+  <!ENTITY I-D.ietf-jsonpath-base PUBLIC ''
+   'https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-jsonpath-base.xml'>
+]>
+<?xml-stylesheet type="text/xsl" href="rfc2629.xslt"?>
+
+<?rfc toc="yes"?>
+<?rfc tocompact="yes"?>
+<?rfc tocdepth="4"?>
+<?rfc compact="yes"?>
+<?rfc subcompact="yes"?>
+<?rfc sortrefs="yes"?>
+<?rfc symrefs="yes"?>
+<?rfc iprnotified="no"?>
+
+<rfc category="std" docName="draft-ietf-regext-rdap-jscontact-16" ipr="trust200902" submissionType="IETF" consensus="true">
+  <front>
+    <title abbrev="Using JSContact in RDAP">Using JSContact in Registration Data Access Protocol
+    (RDAP) JSON Responses</title>
+       
+    <author fullname="Mario Loffredo" initials="M." surname="Loffredo">
+      <organization>IIT-CNR/Registro.it</organization>
+      <address>
+        <postal>
+          <street>Via Moruzzi,1</street>
+          <city>Pisa</city>
+          <country>IT</country>
+          <code>56124</code>
+        </postal>
+        <email>mario.loffredo@iit.cnr.it</email>
+        <uri>http://www.iit.cnr.it</uri>
+      </address>
+    </author>
+
+    <author fullname="Gavin Brown" initials="G" surname="Brown">
+      <organization>CentralNic Group plc</organization>
+      <address>
+        <postal>
+        <street>Saddlers House, 44 Gutter Lane</street>
+        <city>London</city>
+        <region>England</region>
+        <code>EC2V 6BR</code>
+        <country>GB</country>
+        </postal>
+        <phone>+44 20 33 88 0600</phone>
+        <email>gavin.brown@centralnic.com</email>
+        <uri>https://www.centralnic.com</uri>
+      </address>
+    </author>
+
+    <date/>
+    <area>Applications and Real-Time</area>
+    <workgroup>Registration Protocols Extensions</workgroup>
+    <keyword>RDAP</keyword>
+    <keyword>jCard</keyword>
+    <keyword>JSContact</keyword>
+    
+    <abstract>
+      <t>This document describes an RDAP extension which represents entity contact information in
+      JSON responses using JSContact.</t>
+    </abstract>
+  </front>
+
+  <middle>
+    <section title="Introduction">
+      <t>This document specifies an extension to the Registration Data Access Protocol (RDAP)
+      that allows RDAP servers to use JSContact <xref target="I-D.ietf-calext-jscontact"/>
+      to represent the contact information associated with entities in RDAP responses, instead
+      of jCard <xref target="RFC7095"/>.  It also describes the process by which an RDAP server
+      can transition from jCard to JSContact.  RDAP query and response extensions are defined to
+      facilitate the transition process.</t>
+
+      <section anchor="Rationale" title="Rationale">
+        <t>According to the feedback from RDAP Pilot Working Group <xref target="RDAP-PILOT-WG"/>,
+        a group of RDAP server implementers representing registries and registrars of generic
+        TLDs, the most commonly raised implementation concern, for both servers and client
+        implementers, related to the use of jCard <xref target="RFC7095"/> to represent the
+        contact information associated with entities.  Working Group members reported jCard to be
+        unintuitive, complicated to implement for both clients and servers, and incompatible
+        with best practices for RESTful APIs.</t>
+
+        <t>JSContact <xref target="I-D.ietf-calext-jscontact"/> provides a simpler and more
+        efficient representation for contact information with regard to time and effort saved in processing it.  In addition, similarly to jCard, it provides a means to
+        represent internationalised and unstructured contact information.  Support for internationalised contact information has been
+        recognised being necessary to facilitate the future internationalisation of registration
+        data directory services.</t>
+      </section>
+
+      <section anchor="Conventions" title="Conventions Used in This Document">
+        <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <xref target="RFC2119"/> <xref target="RFC8174"/> when, and only when, they appear in all capitals, as shown here.</t>
+
+        <t>The JSContact specification declares the object type &quot;Card&quot; which
+          represents a single contact card.  To avoid confusion, in the following of this document, the term &quot;JSCard&quot; is used to refer to &quot;JSContact Card&quot;.</t>
+      </section>
+    </section>
+      
+    <section anchor="JSContact" title="JSContact">
+      <t>The JSContact specification defines a data model and JSON representation of contact
+        information that can be used for data storage and exchange in address book or directory
+        applications.  It aims to be an alternative to the vCard data format <xref target="RFC6350"/>
+        and to be unambiguous, extendable and simple to process.  In contrast with jCard, it is
+        not a direct mapping from the vCard data model and expands semantics where appropriate.</t>
+      <t>JSCard differs from jCard in that it:</t>
+
+      <t><list style="symbols">
+        <t>follows an object-oriented rather than array-oriented approach;<vspace blankLines='1' /></t>
+        <t>is simple to process;<vspace blankLines='1' /></t>
+        <t>requires no extra work in serialization/deserialization from/to a data model;<vspace blankLines='1' /></t>
+        <t>includes no &quot;jagged&quot; arrays;<vspace blankLines='1' /></t>
+        <t>prefers maps rather than arrays to implement collections.</t>
+      </list></t>
+
+      <t><xref target="I-D.ietf-calext-jscontact-vcard"/> provides informational guidance on the conversion of jCard into JSCard, and vice versa.  <xref target="jcard-jscontact-mapping"/> shows JSContact counterparts for the most commonly used jCard properties in an RDAP response.</t>
+
+    </section>
+
+    <section anchor="using-jscontact" title="Using JSContact objects in RDAP Responses">
+      <t>Entity objects in RDAP responses MAY include a &quot;jscard&quot; property whose value is a JSCard object instead of the &quot;vCardArray&quot; property defined in <xref target="RFC9083"/>.</t>
+      <t>Servers returning the &quot;jscard&quot; property in their response MUST include &quot;jscard&quot; in the &quot;rdapConformance&quot; array.</t>
+      <t>Since most of the JSCard collections are represented as maps, map keys must be defined.  A JSContact map key MUST comply with the definition of the Id type.  To aid interoperability, RDAP providers MUST use the following Id values related to string values and labels defined in <xref target="RFC5733"/>:
+        <list style="symbols">
+          <t>&quot;org&quot; in the &quot;organizations&quot; map when there is a single &lt;contact:org&gt; element.  If both internationalised and localized forms exist, the key MUST be used for the internationalised form;<vspace blankLines='1' /></t>
+          <t>&quot;addr&quot; in the &quot;addresses&quot; map when there is a single &lt;contact:addr&gt; element.  If both internationalised and localized forms exist, the key MUST be used for the internationalised form;<vspace blankLines='1' /></t>
+          <t>&quot;email&quot; in the &quot;emails&quot; map when there is a single &lt;contact:email&gt; element;<vspace blankLines='1' /></t>
+          <t>&quot;voice&quot; in the &quot;phones&quot; map for the &lt;contact:voice&gt; element;<vspace blankLines='1' /></t>
+          <t>&quot;fax&quot; in the &quot;phones&quot; map for the &lt;contact:fax&gt; element.</t>
+        </list>
+      </t>
+      <t>The information needed to register the JSContact Id values in the &quot;RDAP JSON Values&quot; registry <xref target="RFC9083"/> is described in <xref target="rdap-json-values-registry"/>.</t>
+      <t>If present, the localized versions of name, organization and postal address MUST be added to the &quot;localizations&quot; map.  With reference to the defintion of localization in <xref target="I-D.ietf-calext-jscontact"/>, an RDAP response with JSContact content MUST expand all localizations (i.e. a patch key using the syntax &quot;{key1}/{key2}/.../{keyN}&quot; is not allowed).  The following is an elided example of an RDAP entity lookup response including a JSCard object that presents a localized postal address (See PDF for non-ASCII character string).</t>
+      <figure anchor="localizations-example" title="Example of handling localizations in JSContact"><artwork xml:space="preserve">
+...
+"jscard": {
+  "@type" : "Card",
+  "@version" : "1.0",
+  "uid" : "7812cafe-336e-5969-988b-ad68f78ae90f",
+  "language" : "en",
+  "fullName" : "Vasya Pupkin",
+  "organizations" : {
+    "org" : {
+      "name" : "My Company"
+    }
+  },
+  "addresses" : {
+    "addr" : {
+      "street" : [ {
+        "kind" : "name",
+        "value" : "1 Street"
+      }, {
+        "kind" : "postOfficeBox",
+        "value" : "01001"
+      } ],
+      "locality" : "Kyiv",
+      "countryCode" : "UA"
+    }
+  },
+  "localizations" : {
+    "ua" : {
+      "addresses": {
+        "addr" : {
+          "street" : [ {
+            "kind" : "name",
+            "value" : "1, Улица"
+          }, {
+            "kind" : "postOfficeBox",
+            "value" : "01001"
+          } ],
+          "locality" : "Киев",
+          "countryCode" : "UA"
+        }
+      },
+      "fullName" : "Вася Пупкин",
+      "organizations": {
+        "org" : {
+          "name" : "Моя Компания"
+        }
+      }
+    }
+  }
+}
+...
+</artwork></figure>
+
+      <t>Implementers MAY use different mapping schemes to define keys for additional entries of the aforementioned maps or others.  For example, a mapping scheme may consist in using a trivial sequential number (e.g. &quot;url-1&quot;, &quot;url-2&quot;, etc.)</t>
+      <t>The following is an example of an RDAP entity including a JSCard object that has been converted from the example in section 5.1 of <xref target="RFC9083"/>.</t>
+
+<figure anchor="jscard-example" title="Example of using JSContact in RDAP response"><artwork xml:space="preserve">
+   {
+      "rdapConformance": [
+         "rdap_level_0",
+         "jscard"
+      ],
+      "objectClassName" : "entity",
+      "handle":"XXXX",
+      "jscard":{
+        "@type": "Card",
+        "@version": "1.0",
+        "uid": "74b64df3-2d60-56b4-9df3-8594886f4456",
+        "language" : "en",
+        "fullName": "Joe User" ,
+        "name": {
+          "components": [
+            {
+              "type": "surname",
+              "value": "User"
+            },
+            {
+              "type": "given",
+              "value": "Joe"
+            },
+            {
+              "type": "suffix",
+              "value": "ing. jr"
+            },
+            {
+              "type": "suffix",
+              "value": "M.Sc."
+            }
+          ]
+        },
+        "kind": "individual",
+        "preferredLanguages": {
+          "fr": {
+            "pref": 1
+          },
+          "en": {
+            "pref": 2
+          }
+        },
+        "organizations": {
+          "org": {
+            "name": "Example"
+          }
+        },
+        "titles": {
+          "title": {
+            "kind": "title",
+            "name": "Research Scientist"
+          },
+          "role": {
+            "kind": "role",
+            "name": "Project Lead"
+          }
+        },
+        "addresses": {
+          "addr": {
+            "contexts": {
+              "work": true
+            },
+            "street": [
+              {
+                "kind": "name",
+                "value": "4321 Rue Somewhere"
+              },
+              {
+                "kind": "extension",
+                "value": "Suite 1234"
+              }
+            ],
+            "locality": "Quebec",
+            "region": "QC",
+            "postcode": "G1V 2M2",
+            "country": "Canada",
+            "countryCode": "CA",
+            "coordinates": "geo:46.772673,-71.282945",
+            "timeZone": "Etc/GMT+5"
+          },
+          "home": {
+            "contexts": {
+              "private": true
+            },
+            "fullAddress": "123 Maple Ave\nVancouver\nBC\n1239\n"
+          }
+        },
+        "phones": {
+          "voice" : {
+            "contexts": {
+              "work": true
+            },
+            "features": {
+               "voice": true,
+               "mobile": true,
+               "video": true,
+               "text": true
+            },
+            "pref": 1,
+            "number": "tel:+1-555-555-1234;ext=102"
+          }
+        },
+        "emails": {
+          "email": {
+            "contexts": {
+              "work": true
+            },
+            "address": "joe.user@example.com"
+          }
+        },
+        "cryptoKeys": {
+          "contexts": {
+            "work": true
+          },
+          "uri": "https://www.example.com/joe.user/joe.asc"
+        },
+        "links": {
+          "contexts": {
+            "private": true
+          },
+          "uri": "https://example.org"
+        }
+      },
+      "roles":[ "registrar" ],
+      "publicIds":[
+        {
+          "type":"IANA Registrar ID",
+          "identifier":"1"
+        }
+      ],
+      "remarks":[
+        {
+          "description":[
+            "She sells sea shells down by the sea shore.",
+            "Originally written by Terry Sullivan."
+          ]
+        }
+      ],
+      "links":[
+        {
+          "value":"https://example.com/entity/XXXX",
+          "rel":"self",
+          "href":"https://example.com/entity/XXXX",
+          "type" : "application/rdap+json"
+        }
+      ],
+      "events":[
+        {
+          "eventAction":"registration",
+          "eventDate":"1990-12-31T23:59:59Z"
+        }
+      ],
+      "asEventActor":[
+        {
+          "eventAction":"last changed",
+          "eventDate":"1991-12-31T23:59:59Z"
+        }
+      ]
+   }
+</artwork></figure>
+
+     <t>The use of JSContact updates the mappings of two reverse search properties, namely &quot;fn&quot; and &quot;email&quot;, defined in <xref target="I-D.ietf-regext-rdap-reverse-search"/>.  Such new mappings are registered in the Reverse Search Mapping registry as described in <xref target="rdap-reverse-search-mapping-registry"/>.</t>
+
+    <section anchor="rdap-query-parameters-specification" title="RDAP Query Parameters">
+
+      <t>One new query parameter is defined for the purpose of this document.</t>
+
+      <t>The parameter is an OPTIONAL extension of queries defined in <xref target="RFC9082"/> as well as any RDAP query described by a future document whose response includes contact information.  It is as follows:</t>
+
+        <t>&quot;jscard&quot;: a boolean value that allows a client to request the &quot;jscard&quot; property in the RDAP response;</t>
+
+      <t>This parameter is further explained in <xref target="stage2"/>.</t>
+    </section>
+
+    </section>
+
+    <section anchor="transition" title="Transition Considerations">
+
+      <section anchor="rdap-features-supporting-transition" title="RDAP Features Supporting a Transition Process">
+        <section title="Notices and Link Relationships">
+          <t>RDAP allows servers to communicate service information to clients through notices.
+          According to Section 4.3 of <xref target="RFC9083"/>, an RDAP response may contain one or more notice objects. Each notice may include a set of link objects, which can be used to provide clients
+          with references and documentation.  These link objects may have a "rel" property which defines
+          the relationship type, as described in <xref target="RFC8288"/>, Section 4.  The transition
+          process outlined in this document uses two link relation types, namely &quot;related&quot; and &quot;alternate&quot;, described in <xref target="RFC8288"/>.</t>
+        </section>
+
+        <section title="rdapConformance Property">
+          <t>The information about the specifications used in the construction of the response is
+            also described by the strings which appear in the "rdapConformance" property of the RDAP
+            response.</t>
+        </section>
+
+      </section>
+
+      <section anchor="jcard-transition-procedure" title="Transition Procedure">
+
+        <t>The principles of the procedure for jCard to JSCard transition are based on the best practices in <xref
+                target="API-DEPRECATION"/>.</t>
+
+        <t>The procedure consists of three contiguous stages.
+          During the procedure, the presence of &quot;jscard&quot; tag in the rdapConformance array
+          indicates that JSCard is returned instead of jCard.  The date and time format used to notify
+          clients about the stages of this procedure is defined in <xref target="RFC3339" />.</t>
+
+        <section anchor="jcard-deprecation-procedure-goals" title="Goals">
+          <t>The procedure described in this document aims to achieve the following goals:</t>
+          <t><list style="symbols">
+            <t>only one contact representation would be included in the response;<vspace blankLines='1' /></t>
+            <t>the response would always be compliant to <xref target="RFC9083"/> because:
+              <list style="symbols">
+                <t>being the &quot;jscard&quot; property a response extension, its presence would be signaled by the &quot;jscard&quot; conformance tag;<vspace blankLines='1' /></t>
+                <t>being &quot;vcardArray&quot; property optional in a response, its absence would be allowed;<vspace blankLines='1' /></t>
+              </list>
+            </t>
+            <t>clients would be informed about the transition timeline;<vspace blankLines='1' /></t>
+            <t>the backward compatibility would be guaranteed throughout the transition;<vspace blankLines='1' /></t>
+            <t>servers and clients could execute their transitions independently.</t>
+          </list></t>
+        </section>
+
+        <section anchor="jcard-deprecation-procedure-stages" title="Transition Stages">
+
+            <section anchor="stage1" title="Stage 1: only jCard provided">
+              <t>This stage corresponds to providing jCard as the default contact card <xref
+                target="RFC9083" />.  The RDAP server is not able to provide an alternate format for the contact
+                card.  The rdapConformance array MUST NOT contain the &quot;jscard&quot; tag.</t>
+            </section>
+
+            <section anchor="stage2" title="Stage 2: jCard sunset">
+              <t>During this stage, the server uses jCard by default, but the RDAP server will
+                return JSCard if the client sets the query parameter &quot;jscard&quot; to 1/true/yes.
+                The rdapConformance array MUST contain the &quot;jscard&quot; tag if JSCard is
+                returned.</t>
+
+              <t>From this stage on, the RDAP server MUST include the &quot;jscard&quot; tag in the rdapConformance array of the help response to signal clients that JSCard can be returned instead of jCard.</t>
+
+              <t>If JSCard is not requested, the RDAP server SHOULD include a notice titled &quot;jCard sunset end&quot;.  Such
+                a notice includes a description reporting the jCard sunset end date and time and two
+                OPTIONAL links:</t>
+
+              <t><list style="symbols">
+                <t>&quot;related&quot;: a link to a URI-identified resource documenting the transition procedure;<vspace blankLines='1' /></t>
+                <t>&quot;alternate&quot;: a link to an alternate result view identified
+                   by the current query string plus the parameter &quot;jscard&quot;
+                  set to 1/true/yes (<xref target="stage2-example1" />).</t>
+              </list></t>
+
+             <figure anchor="stage2-example1" title="jCard sunset - JSCard not requested"><artwork xml:space="preserve">
+"notices": [
+  {
+    "title": "jCard sunset end",
+    "description": ["2022-12-31T23:59:59Z"],
+    "links": [{
+        "value": "https://example.net/entity/XXXX",
+        "rel": "related",
+        "type": "text/html",
+        "href": "https://www.example.com/jcard_deprecation.html"
+      },
+      {
+        "value": "https://example.net/entity/XXXX",
+        "rel": "alternate",
+        "type": "application/rdap+json",
+        "href": " https://example.net/entity/XXXX?jscard=1"
+      }
+    ]
+  }
+]
+</artwork></figure>
+          </section>
+
+
+        <section anchor="stage3" title="Stage 3: jCard deprecation">
+          <t>This stage corresponds to providing JSCard as default contact card.  The rdapConformance
+            array always contains &quot;jscard&quot; tag.  The RDAP server doesn't include any
+            notice about the jCard deprecation process.  The &quot;jscard&quot; query
+            parameter MUST be ignored.</t>
+
+          <t>FOR DISCUSSION: should server signal the end of the transition by including the "jcard_deprecated" value in the rdapConformance array ? Would its usage be compliant with the rdapConformance definition in RFC 9083 ?</t>
+        </section>
+
+        <section anchor="jcard-deprecation-procedure-length" title="Length">
+          <t>The length of the jCard sunset period is not fixed by this
+            specification.  Best practices in REST API deprecation suggest that, depending on the
+            deprecated API's reach, user base and service offering, a convenient time could be
+            anywhere between 3 - 8 months.  Anyway, RDAP providers are RECOMMENDED to monitor the
+            server log to figure out whether the declared time need to be changed to meet client
+            requirements.</t>
+        </section>
+
+      </section>
+    </section>
+  </section>
+
+    <section anchor="impl-status" title="Implementation Status">
+      <t>NOTE: Please remove this section and the reference to RFC 7942 prior to publication as
+        an RFC.</t>
+      
+      <t>This section records the status of known implementations of the protocol defined by
+        this specification at the time of posting of this Internet-Draft, and is based on a
+        proposal described in RFC 7942 <xref target="RFC7942"/>.  The description of
+        implementations in this section is intended to assist the IETF in its decision processes
+        in progressing drafts to RFCs.  Please note that the listing of any individual
+        implementation here does not imply endorsement by the IETF.  Furthermore, no effort has
+        been spent to verify the information presented here that was supplied by IETF
+        contributors.  This is not intended as, and must not be construed to be, a catalog of
+        available implementations or their features.  Readers are advised to note that other
+        implementations may exist.</t>
+      
+      <t>According to RFC 7942, &quot;this will allow reviewers and working groups to assign due
+        consideration to documents that have the benefit of running code, which may serve as
+        evidence of valuable experimentation and feedback that have made the implemented
+        protocols more mature.  It is up to the individual working groups to use this information
+        as they see fit&quot;.</t>
+      
+      <section anchor="registro-it-rdap-server" title="IIT-CNR/Registro.it RDAP Server">
+        <t><list style="none">
+    	  <t>Responsible Organization: Institute of Informatics and Telematics of National
+          Research Council (IIT-CNR)/Registro.it<vspace blankLines='1' /></t>
+    	  <t>Location: <eref target="https://rdap.pubtest.nic.it/domain/nic.it?jscard=1">https://rdap.pubtest.nic.it/</eref><vspace blankLines='1' /></t>
+    	  <t>Description: This implementation includes support for RDAP queries using data from
+          the public test environment of .it ccTLD.<vspace blankLines='1' /></t>
+    	  <t>Level of Maturity: This is an &quot;alpha&quot; test implementation.<vspace blankLines='1' /></t>
+    	  <t>Coverage: This implementation includes all of the features described in this
+          specification.<vspace blankLines='1' /></t>
+    	  <t>Contact Information: Mario Loffredo, mario.loffredo@iit.cnr.it</t>
+    	</list></t>
+      </section>
+
+      <section anchor="registro-it-rdap-client" title="IIT-CNR/Registro.it RDAP Client">
+        <t><list style="none">
+          <t>Responsible Organization: Institute of Informatics and Telematics of National
+            Research Council (IIT-CNR)/Registro.it<vspace blankLines='1' /></t>
+          <t>Location: https://web-rdap.pubtest.nic.it/<vspace blankLines='1' /></t>
+          <t>Description: This is a Javascript web-based RDAP client. RDAP responses are
+            retrieved from RDAP servers by the browser, parsed into an HTML representation, and displayed in a format improving the user experience.
+            RDAP responses containing JSCard objects are handled identically to those containing
+            jCard objects.  Raw versions of RDAP responses including either jCard or JSCard objects are provided.<vspace blankLines='1' /></t>
+          <t>Level of Maturity: This is an &quot;alpha&quot; test implementation.<vspace blankLines='1' /></t>
+          <t>Coverage: This implementation includes all of the features described in this
+            specification.<vspace blankLines='1' /></t>
+          <t>Contact Information: Francesco Donini, francesco.donini@iit.cnr.it</t>
+        </list></t>
+      </section>
+
+      <section anchor="client-rdap-org" title="client.rdap.org">
+        <t><list style="none">
+    	  <t>Location: https://client.rdap.org/<vspace blankLines='1' /></t>
+    	  <t>Description: This is a web-based &quot;single page&quot; RDAP client. RDAP responses are
+          retrieved from RDAP servers by the browser, and parsed into an HTML representation.
+          RDAP responses containing JSCard objects are handled identically to those containing
+          jCard objects.<vspace blankLines='1' /></t>
+    	  <t>Level of Maturity: This is an &quot;alpha&quot; test implementation.<vspace blankLines='1' /></t>
+    	  <t>Coverage: This implementation implements client support for parsing JSCard objects
+          in RDAP responses.<vspace blankLines='1' /></t>
+    	  <t>Contact Information: Gavin Brown, feedback@rdap.org</t>
+    	</list></t>
+      </section>
+
+      <section anchor="cnic" title="CentralNic Registry">
+        <t><list style="none">
+    	  <t>Responsible Organization: CentralNic Group PLC<vspace blankLines='1' /></t>
+    	  <t>Location: https://rdap.centralnic.com/{tld}<vspace blankLines='1' /></t>
+    	  <t>Description: This server is the product RDAP service for all top-level domains on the
+          CentralNic registry platform.<vspace blankLines='1' /></t>
+    	  <t>Level of Maturity: Production quality.<vspace blankLines='1' /></t>
+    	  <t>Coverage: This implementation includes all of the features described in this
+          specification.<vspace blankLines='1' /></t>
+    	  <t>Contact Information: support@centralnic.com</t>
+    	</list></t>
+      </section>
+
+    </section>
+
+   <section anchor="IANA-considerations" title="IANA Considerations">
+
+
+    <section anchor="rdap-extensions-registry" title="RDAP Extensions Registry">
+
+     <t>IANA is requested to register the following values in the RDAP Extensions Registry:</t>
+
+     <t><list style="none">
+       <t>Extension identifier: jscard<vspace blankLines='1' /></t>
+       <t>Registry operator: Any<vspace blankLines='1' /></t>
+       <t>Published specification: This document.<vspace blankLines='1' /></t>
+       <t>Contact: IETF &lt;iesg@ietf.org&gt;<vspace blankLines='1' /></t>
+       <t>Intended usage: This extension prefix identifier is used for the &quot;jscard&quot; member returned in the JSON response <xref target="I-D.ietf-calext-jscontact"/>.</t>
+     </list></t>
+
+    </section>
+
+
+    <section anchor="rdap-json-values-registry" title="RDAP JSON Values Registry">
+
+      <t>With regard to the fields of the &quot;RDAP JSON Values&quot; registry <xref target="RFC9083"/>, the &quot;JSContact Id Value&quot; type SHALL be used to register the RDAP values for the JSContact Id type as defined in <xref target="using-jscontact"/>.</t>
+      <t>IANA is requested to register the following values in the &quot;RDAP JSON Values&quot; registry:</t>
+
+      <t>
+        <list style="hanging">
+          <t hangText="Value:">org</t>
+          <t hangText="Type:">JSContact Id Value</t>
+          <t hangText="Description:">The key in the JSContact &quot;organizations&quot; map identifiying the contact organization.</t>
+          <t hangText="Registrant Name:">IESG</t>
+          <t hangText="Registrant Contact Information:">iesg@ietf.org</t>
+          <t hangText="Reference:">This document</t>
+        </list>
+        <list style="hanging">
+          <t hangText="Value:">addr</t>
+          <t hangText="Type:">JSContact Id Value</t>
+          <t hangText="Description:">The key in the JSContact &quot;addresses&quot; map identifiying the unique or preferred contact postal address.</t>
+          <t hangText="Registrant Name:">IESG</t>
+          <t hangText="Registrant Contact Information:">iesg@ietf.org</t>
+          <t hangText="Reference:">This document</t>
+        </list>
+        <list style="hanging">
+          <t hangText="Value:">email</t>
+          <t hangText="Type:">JSContact Id Value</t>
+          <t hangText="Description:">The key in the JSContact &quot;emails&quot; map identifiying the unique or preferred contact email address.</t>
+          <t hangText="Registrant Name:">IESG</t>
+          <t hangText="Registrant Contact Information:">iesg@ietf.org</t>
+          <t hangText="Reference:">This document</t>
+        </list>
+        <list style="hanging">
+          <t hangText="Value:">voice</t>
+          <t hangText="Type:">JSContact Id Value</t>
+          <t hangText="Description:">The key in the JSContact &quot;phones&quot; map identifiying the unique or preferred contact voice number.</t>
+          <t hangText="Registrant Name:">IESG</t>
+          <t hangText="Registrant Contact Information:">iesg@ietf.org</t>
+          <t hangText="Reference:">This document</t>
+        </list>
+        <list style="hanging">
+          <t hangText="Value:">fax</t>
+          <t hangText="Type:">JSContact Id Value</t>
+          <t hangText="Description:">The key in the JSContact &quot;phones&quot; map identifiying the unique or preferred contact fax number.</t>
+          <t hangText="Registrant Name:">IESG</t>
+          <t hangText="Registrant Contact Information:">iesg@ietf.org</t>
+          <t hangText="Reference:">This document</t>
+        </list>
+      </t>
+    </section>
+    <section anchor="rdap-reverse-search-mapping-registry" title="RDAP Reverse Search Mapping Registry">
+
+      <t>IANA is requested to register the following entries in the the &quot;RDAP Reverse Search Mapping&quot; registry <xref target="I-D.ietf-regext-rdap-reverse-search"/>:</t>
+      <t>
+        <list style="hanging">
+          <t hangText="Searchable Resource Type:">domains, nameservers, entities</t>
+          <t hangText="Related Resource Type:">entity</t>
+          <t hangText="Property:">fn</t>
+          <t hangText="Property Path:">$.entities[*].jscard.[fullName,localizations.*.fullName]</t>
+          <t hangText="Registrant Name:">IESG</t>
+          <t hangText="Registrant Contact Information:">iesg@ietf.org</t>
+          <t hangText="Reference:">This document</t>
+        </list>
+        <list style="hanging">
+          <t hangText="Searchable Resource Type:">domains, nameservers, entities</t>
+          <t hangText="Related Resource Type:">entity</t>
+          <t hangText="Property:">email</t>
+          <t hangText="Property Path:">$.entities[*].jscard.emails.email.address</t>
+          <t hangText="Registrant Name:">IESG</t>
+          <t hangText="Registrant Contact Information:">iesg@ietf.org</t>
+          <t hangText="Reference:">This document</t>
+        </list>
+      </t>
+
+    </section>
+
+   </section>
+
+   <section anchor="security-considerations" title="Security Considerations">
+  	<t>Unlike what happens for the &quot;fn&quot; property in jCard, the only mandatory property in JSContact, namely &quot;uid&quot;, is not a sensitive information.  Nevertheless, RDAP operators can redact it to prevent results from being correlated.  Hence, with reference to what is described in <xref target="I-D.ietf-regext-rdap-redacted"/>, a redaction method must be selected based on the &quot;uid&quot; format.</t>
+    <t>If &quot;uid&quot; is represented as a URN in the uuid namespace, the most appropriate choice is using the &quot;Replacement Value&quot; method along with the nil UUID as replacing value.  If it is provided in the free-text format, the &quot;Empty Value&quot; method should be preferred.  Otherwise, an URI value can be redacted by using any of the two methods above.  For example, the URL of the RDAP entity corresponding to the contact (e.g. &quot;https://example.com/rdap/entity/XYZ12345&quot;) can be redacted by replacing the entity handle with a fixed literal (e.g &quot;https://example.com/rdap/entity/XXXXX&quot;).</t>
+   </section>
+
+    <section anchor="Acknowledgements" title="Acknowledgements">
+      <t>The authors would like to acknowledge the following individuals for their contributions to this document: Jasdip Singh, Andrew Newton, Marc Blanchet, Rick Wilhelm and Francesco Donini.</t>
+    </section>
+
+  </middle>
+
+  <back>
+    <references title="Normative References">
+      &I-D.ietf-calext-jscontact;
+      &I-D.ietf-calext-jscontact-vcard;
+      &I-D.ietf-regext-rdap-reverse-search;
+      &RFC2119;
+      &RFC3339;
+      &RFC5733;
+      &RFC6350;
+      &RFC7095;
+      &RFC9082;
+      &RFC9083;
+      &RFC7942;
+      &RFC8174;
+      &RFC8288;
+    </references>
+
+    <references title="Informative References">
+      &I-D.ietf-jsonpath-base;
+      &I-D.ietf-regext-rdap-redacted;
+      &RFC8605;
+      <reference anchor='RDAP-PILOT-WG'
+        target='https://www.icann.org/en/system/files/files/rdap-pilot-report-25apr19-en.pdf'>
+        <front>
+          <title>RDAP Pilot Report</title>
+          <author>
+            <organization>ICANN RDAP Pilot WG</organization>
+          </author>
+          <date year='2019' month='April' />
+        </front>
+      </reference>
+      <reference anchor='API-DEPRECATION'
+        target='https://web.archive.org/web/20200417084255/https://nordicapis.com/how-to-smartly-sunset-and-deprecate-apis/'>
+        <front>
+          <title>How to Smartly Sunset and Deprecate APIs</title>
+          <author initials="K." surname="Sandoval" fullname="Kristopher Sandoval" />
+          <date year='2019' month='August' />
+        </front>
+      </reference>
+    </references>
+
+    <section anchor="jcard-jscontact-mapping" title="jCard-JSContact Mapping">
+
+      <t>Provided that the keys defined in <xref target="using-jscontact"/> are used for the JSContact maps, the mapping between the most commonly used jCard properties in an RDAP response and their JSContact counterparts is shown in the following.  The mapping is done through the use of JSONPath expressions <xref target="I-D.ietf-jsonpath-base"/>.</t>
+
+      <t>
+      <list style="hanging" >
+        <t hangText="jCard property:">fn</t>
+        <t hangText="Reference:">Section 6.2.1 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='fn')][3]</t>
+        <t hangText="JSContact property:">fullName</t>
+        <t hangText="Reference:">Section 2.2.1 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[fullName,localizations.*.fullName]</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">org</t>
+        <t hangText="Reference:">Section 6.6.4 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='org')][3]</t>
+        <t hangText="JSContact property:">Organization.name</t>
+        <t hangText="Reference:">Section 2.2.4 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[organizations.org.name,localizations.*.organizations.org.name]</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">tel with type=&quot;voice&quot;</t>
+        <t hangText="Reference:">Section 6.4.1 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[1].type=='voice')][3]</t>
+        <t hangText="JSContact property:">Phone.number</t>
+        <t hangText="Reference:">Section 2.3.3 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.phones.voice.number</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">tel with type=&quot;fax&quot;</t>
+        <t hangText="Reference:">Section 6.4.1 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[1].type=='fax')][3]</t>
+        <t hangText="JSContact property:">Phone.number</t>
+        <t hangText="Reference:">Section 2.3.3 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.phones.fax.number</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">email</t>
+        <t hangText="Reference:">Section 6.4.2 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='email')][3]</t>
+        <t hangText="JSContact property:">Email.address</t>
+        <t hangText="Reference:">Section 2.3.1 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[emails.email.address,localizations.*.emails.email.address]</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">&quot;post office box&quot; component of adr</t>
+        <t hangText="Reference:">Section 6.3.1 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='adr')][3][1]</t>
+        <t hangText="JSContact property:">&quot;postOfficeBox&quot; StreetComponent of Address.street</t>
+        <t hangText="Reference:">Section 2.5.1 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[addresses.addr.street[?(@.type=='postOfficeBox')].value,localizations.*.addresses.addr.street[?(@.type=='postOfficeBox')].value]</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">&quot;street address&quot; component of adr</t>
+        <t hangText="Reference:">Section 6.3.1 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='adr')][3][2]</t>
+        <t hangText="JSContact property:">&quot;name&quot; StreetComponent of Address.street</t>
+        <t hangText="Reference:">Section 2.5.1 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[addresses.addr.street[?(@.type=='name')].value,localizations.*.addresses.addr.street[?(@.type=='name')].value]</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">&quot;locality&quot; component of adr</t>
+        <t hangText="Reference:">Section 6.3.1 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='adr')][3][3]</t>
+        <t hangText="JSContact property:">Address.locality</t>
+        <t hangText="Reference:">Section 2.5.1 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[addresses.addr.locality,localizations.*.addresses.addr.locality]</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">&quot;region&quot; component of adr</t>
+        <t hangText="Reference:">Section 6.3.1 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='adr')][3][4]</t>
+        <t hangText="JSContact property:">Address.region</t>
+        <t hangText="Reference:">Section 2.5.1 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[addresses.addr.region,localizations.*.addresses.addr.region]</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">&quot;postal code&quot; component of adr</t>
+        <t hangText="Reference:">Section 6.3.1 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='adr')][3][5]</t>
+        <t hangText="JSContact property:">Address.postcode</t>
+        <t hangText="Reference:">Section 2.5.1 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[addresses.addr.postcode,localizations.*.addresses.addr.postcode]</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">&quot;country name&quot; component of adr</t>
+        <t hangText="Reference:">Section 6.3.1 of <xref target="RFC6350"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='adr')][3][6]</t>
+        <t hangText="JSContact property:">Address.country</t>
+        <t hangText="Reference:">Section 2.5.1 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[addresses.addr.country,localizations.*.addresses.addr.country]</t>
+      </list>
+      </t>
+      <t>
+      <list style="hanging">
+        <t hangText="jCard property:">&quot;cc&quot; parameter of adr</t>
+        <t hangText="Reference:">Section 3.1 of <xref target="RFC8605"/></t>
+        <t hangText="Path:">$..vcardArray[1][?(@[0]=='adr')][1].cc</t>
+        <t hangText="JSContact property:">Address.countryCode</t>
+        <t hangText="Reference:">Section 2.5.1 of <xref target="I-D.ietf-calext-jscontact"/></t>
+        <t hangText="Path:">$..jscard.[addresses.addr.countryCode,localizations.*.addresses.addr.countryCode]</t>
+        <!--
+        <t hangText="Path:">$..jscard..addresses.addr.countryCode</t>
+        -->
+      </list>
+      </t>
+    </section>
+
+    <section title="Change Log">
+
+      <section title="Change from 00 to 01">
+        <t><list style="numbers">
+          <t>Changed category from &quot;Best Current Practice&quot; to &quot;Standards
+            Track&quot;</t>
+          <t>Replaced the example of <xref target="jscard-example"/></t>
+          <t>Changed the title of the &quot;Migration from JCard to JSCard&quot; section to
+            &quot;Transition Considerations&quot;</t>
+          <t>Added <xref target="rdap-query-parameters-specification"/></t>
+          <t>Updated <xref target="IANA-considerations"/></t>
+          <t>Updated <xref target="security-considerations"/></t>
+          <t>Rearranged the description of stage 1 in <xref target="jcard-deprecation-procedure-stages"/></t>
+          <t>Changed the names of the transition stages 1 and 2</t>
+          <t>Corrected examples</t>
+          <t>Changed the rdapConformance tag &quot;jscard_level_0&quot; to &quot;jscard&quot;</t>
+          <t>Removed the &quot;Best Practices for deprecating a REST API features&quot; section,but added a useful reference.</t>
+        </list></t>
+      </section>
+      <section title="Change from 01 to 02">
+        <t><list style="numbers">
+          <t>Removed the sentence &quot;which cannot be represented using jCard&quot; in <xref target="Rationale"/>.</t>
+        </list></t>
+      </section>
+      <section title="Change from 02 to 03">
+        <t><list style="numbers">
+          <t>Updated section &quot;Conventions Used in This Document&quot;.</t>
+          <t>Updated the contact in &quot;IANA Considerations&quot; section.</t>
+          <t>Changed the reference draft-loffredo-calext-jscontact-vcard to draft-ietf-calext-jscontact-vcard.</t>
+          <t>Added reference to RFC8174.</t>
+          <t>Other minor edits.</t>
+        </list></t>
+      </section>
+      <section title="Change from 03 to 04">
+        <t><list style="numbers">
+          <t>Updated the reference draft-dalal-deprecation-header to draft-ietf-httpapi-deprecation-header.</t>
+        </list></t>
+      </section>
+      <section title="Initial WG version">
+      <t><list style="numbers">
+        <t>Ported from draft-loffredo-regext-rdap-jcard-deprecation-04 renamed to draft-ietf-regext-rdap-jscontact-00.</t>
+      </list></t>
+      </section>
+      <section title="Change from 00 to 01">
+        <t><list style="numbers">
+          <t>Updated <xref target="using-jscontact"/> and <xref target="jscard-example"/>.</t>
+        </list></t>
+      </section>
+      <section title="Change from 01 to 02">
+        <t><list style="numbers">
+          <t>Updated <xref target="JSContact"/> and <xref target="jscard-example"/>.</t>
+        </list></t>
+      </section>
+      <section title="Change from 02 to 03">
+        <t><list style="numbers">
+          <t>Replaced references to obsolete RFC7482 and RFC7483 with RFC9082 and RFC9083.</t>
+          <t>Updated <xref target="using-jscontact"/> and <xref target="jscard-example"/>.</t>
+        </list></t>
+      </section>
+      <section title="Change from 03 to 04">
+        <t><list style="numbers">
+          <t>Changed the references to Internet Drafts.</t>
+          <t>Added an example showing how localizations are treated in JSContact.</t>
+          <t>Changed the position of section &quot;Goals&quot; in <xref target="jcard-transition-procedure"/>.</t>
+          <t>Added three more implementations to <xref target="impl-status"/>.</t>
+          <t>Changed the rdapConformance tag &quot;jscard&quot; to &quot;jscard_0&quot;</t>
+          <t>Added clarifications addressing the feedback provided by Jasdip Singh about version -03.</t>
+          <t>Added <xref target="Acknowledgements"/>.</t>
+          <t>Other minor edits.</t>
+        </list></t>
+      </section>
+      <section title="Change from 04 to 05">
+        <t><list style="numbers">
+          <t>Updated <xref target="jscard-example"/> to make it compliant with draft-ietf-jmap-jscontact-09.</t>
+        </list></t>
+      </section>
+      <section title="Change from 05 to 06">
+        <t><list style="numbers">
+          <t>Reviewed the notices presented in stages.</t>
+        </list></t>
+      </section>
+      <section title="Change from 06 to 07">
+        <t><list style="numbers">
+          <t>Corrected the JSON Pointer expressions in <xref target="localizations-example"/>.</t>
+          <t>Other minor edits.</t>
+        </list></t>
+      </section>
+      <section title="Change from 07 to 08">
+        <t><list style="numbers">
+          <t>Corrected a nit in <xref target="localizations-example"/>.</t>
+          <t>Removed the reference to draft-ietf-httpapi-deprecation-header.</t>
+          <t>Replaced the &quot;deprecation&quot; link relation type with &quot;related&quot;.</t>
+          <t>Moved the references to JSContact drafts to the &quot;Normative References&quot; section.</t>
+        </list></t>
+      </section>
+      <section title="Change from 08 to 09">
+        <t><list style="numbers">
+          <t>Updated the references to JSContact drafts due to the transfer from JMAP to CalExt.</t>
+        </list></t>
+      </section>
+      <section title="Change from 09 to 10">
+        <t><list style="numbers">
+          <t>Updated <xref target="jscard-example"/> to make it compliant with draft-ietf-calext-jscontact-02.</t>
+        </list></t>
+      </section>
+      <section title="Change from 10 to 11">
+        <t><list style="numbers">
+          <t>Added Appendix &quot;jCard-JSContact Mapping&quot;.</t>
+        </list></t>
+      </section>
+      <section title="Change from 11 to 12">
+        <t><list style="numbers">
+          <t>Renamed the &quot;jscard&quot; property to &quot;jscard_0&quot;.</t>
+          <t>Corrected JSONPath expressions in <xref target="jcard-jscontact-mapping"/>.</t>
+        </list></t>
+      </section>
+      <section title="Change from 12 to 13">
+        <t><list style="numbers">
+          <t>Reverted the names of response extension, the rdapConformance tag and extension identifier from  &quot;jscard_0&quot; to &quot;jscard&quot;.</t>
+          <t>Corrected <xref target="localizations-example"/> by removing initial '/' character from JSONPath notations related to localizations.</t>
+        </list></t>
+      </section>
+      <section title="Change from 13 to 14">
+        <t><list style="numbers">
+          <t>Corrected <xref target="jscard-example"/> by replacing &quot;online&quot; property with &quot;cryptoKeys&quot; and &quot;links&quot; properties.</t>
+        </list></t>
+      </section>
+      <section title="Change from 14 to 15">
+        <t><list style="numbers">
+          <t>Corrected <xref target="localizations-example"/>, <xref target="jscard-example"/> and <xref target="jcard-jscontact-mapping"/> to make them compliant with draft-ietf-calext-jscontact-06.</t>
+          <t>Removed mention of JSContact CardGroup object.</t>
+          <t>Renamed and changed <xref target="using-jscontact"/>.</t>
+          <t>Added <xref target="rdap-json-values-registry"/>.</t>
+        </list></t>
+      </section>
+      <section title="Change from 14 to 15">
+        <t><list style="numbers">
+          <t>Corrected <xref target="localizations-example"/>, <xref target="jscard-example"/> and <xref target="jcard-jscontact-mapping"/> to make them compliant with draft-ietf-calext-jscontact-06.</t>
+          <t>Removed mention of JSContact CardGroup object.</t>
+          <t>Renamed and changed <xref target="using-jscontact"/>.</t>
+          <t>Added <xref target="rdap-json-values-registry"/>.</t>
+        </list></t>
+      </section>
+      <section title="Change from 15 to 16">
+        <t><list style="numbers">
+          <t>Replaced JSContact &quot;type&quot; with &quot;kind&quot; in figures.</t>
+          <t>Removed &quot;jCard deprecation&quot; stage and &quot;jcard&quot; query parameter.</t>
+          <t>Renamed &quot;jCard deprecated&quot; stage into &quot;jCard deprecation&quot;.</t>
+          <t>Rephrased <xref target="security-considerations"/>.</t>
+          <t>Corrected JSContact examples based on draft-ietf-calext-jscontact-11.</t>
+          <t>Fixed nits.</t>
+        </list></t>
+      </section>
+    </section>
+  </back>
+</rfc>


### PR DESCRIPTION
Defined how JSContact can be redacted in RDAP.
Update examples to be compliant with last version of JSContact spec.